### PR TITLE
SKILL.md: make frontmatter description bilingual (EN + ZH)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-shotcraft
-description: 用镜头配方卡 + 已验收模板 + 代码/音频资产制作电影感产品视频（Remotion + 真实页面截图 + 2.5D 运镜 + 节奏卡点 + 声音设计）。当用户要求"用 video-shotcraft 做视频/宣传片"、把前端项目/网页做成产品视频、点名 Ink Press 模板或要求复刻模板片效果，或要用镜头卡做单个动效镜头时使用。
+description: Create cinematic product videos from shot recipe cards, a validated template, and code/audio assets (Remotion + real page screenshots + 2.5D camera moves + beat-synced cuts + sound design). Use when the user asks to turn a frontend project or webpage into a product video, says "use video-shotcraft to make a video/promo", names the Ink Press template or asks to reproduce its effect, or wants a single shot card's motion. 用镜头配方卡 + 已验收模板 + 代码/音频资产制作电影感产品视频（Remotion + 真实页面截图 + 2.5D 运镜 + 节奏卡点 + 声音设计）。当用户要求"用 video-shotcraft 做视频/宣传片"、把前端项目/网页做成产品视频、点名 Ink Press 模板或要求复刻模板片效果，或要用镜头卡做单个动效镜头时使用。
 ---
 
 # video-shotcraft：电影感产品视频制作


### PR DESCRIPTION
The frontmatter description field is what an agent matches against task phrasing, but it was Chinese-only. This adds an English translation ahead of the original Chinese text so English-phrased tasks activate the skill reliably too. Nothing else in SKILL.md is changed.

Separately, from the same test session: the packaged skill lands as roughly 164MB and 686 files per project-level install, and gallery/demos are human-preview material the agent itself never reads. Not turned into a change here, just flagging it in case an install-size option is worth considering. Comparison write-up: https://skillstested.com/compare/video-shotcraft-vs-remotion-skills/