### PR TITLE
fix: 双版本渲染提前到终检前；--props 改用 JSON 文件跨平台写法

### DIFF
--- a/references/pipeline.md
+++ b/references/pipeline.md
@@ -339,9 +339,16 @@ tokens、启动方式和数据风险。根据项目证据和用户已有描述�
 **具体操作**：
 
 1. 全片渲染最新版，ffmpeg 抽全部关键帧（每镜头至少：入场中、
-   动作峰值、落定后三帧）。
+   动作峰值、落定后三帧）。配了 BGM 的片子在此处就渲出两版——带 BGM 版
+   和无 BGM 版（保留 SFX），无 BGM 版靠阶段 6 预留的 `bgm` inputProp
+   从同一时间线渲出：写一个 `props-nobgm.json`（内容 `{"bgm":false}`）
+   然后 `npx remotion render … --props=props-nobgm.json`（跨平台可靠；
+   macOS/Linux 也可内联 `--props='{"bgm":false}'`，Windows shell 会剥掉
+   内联 JSON 的双引号，必须走文件）。不另建工程、不用 ffmpeg 后期抽轨。
+   命名区分（如 `promo.mp4` / `promo-nobgm.mp4`）。
 2. **独立终检（必做）**：派一个干净上下文的 subagent 做第三方审查。
-   不给它制作过程中的辩解、修改历史或“应该通过”的暗示，只提供：最新版成片、
+   不给它制作过程中的辩解、修改历史或“应该通过”的暗示，只提供：最新版成片
+   （配 BGM 的片子含两版，供 A8 校验）、
    抽出的关键帧、创作模式、产品简报、需求到执行决策表、确认或记录的视觉方向/tokens、styleframe 或跳过理由、
    功能到镜头映射、
    Gallery 卡名与具体变体、`library.json` 中对应记录、卡片文档定位到的准确
@@ -360,10 +367,7 @@ tokens、启动方式和数据风险。根据项目证据和用户已有描述�
    全部切点误差 ≤3f 才算过。
 6. 审查报告的修复项回到阶段 3/5/6 小循环：方案或分镜偏差回阶段 3，画面实现
    问题回阶段 5，声音问题回阶段 6；直到 checklist 通过后终渲出片。
-7. **双版本终渲**：配了 BGM 的片子固定交付两版——带 BGM 版和无 BGM 版
-   （保留 SFX）。无 BGM 版靠阶段 6 预留的 `bgm` inputProp 从同一时间线
-   渲出（`npx remotion render … --props='{"bgm":false}'`），不另建工程、
-   不用 ffmpeg 后期抽轨。命名区分（如 `promo.mp4` / `promo-nobgm.mp4`），
+   终渲重复步骤 1 的双版本渲染——配 BGM 的片子交付带 BGM / 无 BGM 两版，
    无 BGM 版方便用户后期自配音乐或平台配乐。
 
 **产出**：独立审查报告（final-review + aesthetic-rules checklist + 帧号证据）

--- a/references/sound-design.md
+++ b/references/sound-design.md
@@ -17,7 +17,7 @@
 
 **顺序：画面结构基本锁定 → 先铺 BGM 定能量骨架 → 逐拍钉 SFX。**
 
-1. **BGM 先行，定能量骨架。** 一条 BGM 全片铺底，音量包络用 `interpolate` 做首尾淡入淡出（模板片 `[0, 30, TOTAL-50, TOTAL] → [0, 0.34, 0.34, 0]`，即 1s 淡入、1.7s 淡出）。BGM 音量压在 0.34 左右给 SFX 留 headroom。曲子的能量曲线要和分镜表的能量曲线对得上（低开 → 中段推进 → outro 峰值），候选曲必须垫进成片试听——单听曲子无法判断气质（S1）。BGM 的 `<Audio>` 用布尔 inputProp（如 `bgm`，默认 `true`）包住挂载，SFX 不受该开关影响——配了 BGM 的片子终渲交付固定出两版成片，无 BGM 版用 `npx remotion render … --props='{"bgm":false}'` 从同一时间线渲出。
+1. **BGM 先行，定能量骨架。** 一条 BGM 全片铺底，音量包络用 `interpolate` 做首尾淡入淡出（模板片 `[0, 30, TOTAL-50, TOTAL] → [0, 0.34, 0.34, 0]`，即 1s 淡入、1.7s 淡出）。BGM 音量压在 0.34 左右给 SFX 留 headroom。曲子的能量曲线要和分镜表的能量曲线对得上（低开 → 中段推进 → outro 峰值），候选曲必须垫进成片试听——单听曲子无法判断气质（S1）。BGM 的 `<Audio>` 用布尔 inputProp（如 `bgm`，默认 `true`）包住挂载，SFX 不受该开关影响——配了 BGM 的片子终渲交付固定出两版成片，无 BGM 版从同一时间线渲出：`npx remotion render … --props=props-nobgm.json`（文件内容 `{"bgm":false}`；Windows shell 会剥掉内联 JSON 的双引号，走文件最稳，macOS/Linux 也可内联 `--props='{"bgm":false}'`）。
 2. **词汇表按"片种"选，不按"事件"选（S1）。** 产品宣传片的 SFX 词汇 = whoosh(运镜) / impact(落地) / riser(铺垫) / sparkle(光效，目录 `light/`) / transition(转场)，禁用游戏音包**音色**（合成器 pluck/bloop、卡通弹跳）。模板片第一版按 UI 事件语义选音（click/drop/confirmation），用户一耳朵判死刑"太像游戏了"。
    **禁的是音色不是动作**：画面真有点击/开关/碎裂就该配它的拟音（模板片自己用 `click-camera.mp3` 并给了全片最高响度 0.6）；但 `sfx/ui/` 需逐个试听——里面既有真实开关拟音也有合成反馈音，后者正属本条排除的质感（取舍表见 3.3）；`sfx/glass/` 是真实碎裂材质音。判别问句见 aesthetic-rules S1。
 3. **SFX 逐拍钉帧、声明式表集中管理（S2）。** SFX 是 `{ from, src, volume }[]` 数组，逐条注释对应的画面动作（"hero card: whoosh up on the pop"），渲染时每条包一个 `<Sequence from={s.from}>`。杜绝凭感觉铺音效。

--- a/template/TEMPLATE.md
+++ b/template/TEMPLATE.md
@@ -87,6 +87,7 @@
 - SFX 用电影系词汇（whoosh/impact/riser/sparkle/transition），
   禁游戏 UI 音色；结尾固定句式 riser→impact→sparkle
 - 复现片若加了 BGM，终渲固定交付两版：带 BGM 版 + 无 BGM 版（保留 SFX），
-  BGM `<Audio>` 用 `bgm` inputProp 包住，从同一时间线
-  `--props='{"bgm":false}'` 渲出无 BGM 版
+  BGM `<Audio>` 用 `bgm` inputProp 包住，从同一时间线渲出无 BGM 版：
+  `--props=props-nobgm.json`（内容 `{"bgm":false}`；Windows 内联 JSON
+  会被 shell 剥引号，走文件）
 - 确定性渲染：无 Math.random/Date.now，一切伪随机用固定种子


### PR DESCRIPTION
修复 #18 评审发现的两个问题：

## P1：A8 在双版本产出前执行，实际无法验收

原阶段 7 流程中步骤 2–3 调用 final-review.md（含 A8 两版成片校验），但双版本渲染排在步骤 7——独立审查时手里只有一个成片，A8 必然失败或被跳过。

修复：双版本渲染前移到**步骤 1**（首次全片渲染时就出两版），步骤 2 的终检输入明确包含两版成片供 A8 校验；原步骤 7 并入步骤 6 的终渲收口（"终渲重复步骤 1 的双版本渲染"）。

## P2：内联 --props 在 Windows 上不可用

Windows shell 会剥掉内联 JSON 的双引号（[Remotion CLI 文档](https://www.remotion.dev/docs/cli/render#--props)），`--props='{"bgm":false}'` 无法工作。

修复：pipeline.md / sound-design.md / TEMPLATE.md 三处统一改为主推 `--props=props-nobgm.json` 文件写法（内容 `{"bgm":false}`），内联写法降级为 macOS/Linux 可选项并注明 Windows 限制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)