### PR TITLE
docs: README 首屏加 AtomGit 扁平 Star 徽章（G-Star 入驻要求）

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Special thanks to:
 - **Claude Code** — this library itself was built, iterated, and QA'd with an
   AI coding agent, using the same workflow the skill teaches.
 
+## 🌏 Mirror
+
+For faster access from mainland China, this repo is also hosted on AtomGit:
+[atomgit.com/VincentWei/video-shotcraft](https://atomgit.com/VincentWei/video-shotcraft)
+(read-only mirror, auto-synced; GitHub remains the primary home).
+
 ## ⭐ Star history
 
 <a href="https://www.star-history.com/?repos=Vincentwei1021%2Fvideo-shotcraft&type=date&legend=top-left">

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/Vincentwei1021/video-shotcraft)](https://github.com/Vincentwei1021/video-shotcraft/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/Vincentwei1021/video-shotcraft)](https://github.com/Vincentwei1021/video-shotcraft/network/members)
 [![Gallery](https://img.shields.io/badge/Gallery-live%20previews-d3923c)](https://vincentwei1021.github.io/video-shotcraft/)
+[![AtomGit Star](https://atomgit.com/VincentWei/video-shotcraft/star/badge.svg)](https://atomgit.com/VincentWei/video-shotcraft)
 
 <a href="https://trendshift.io/repositories/88911?utm_source=trendshift-badge&utm_medium=badge&utm_campaign=badge-trendshift-88911" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/88911/daily?language=TypeScript" alt="Vincentwei1021%2Fvideo-shotcraft | Trendshift" width="250" height="55"/></a>
 <a href="https://trendshift.io/repositories/88911?utm_source=trendshift-badge&utm_medium=badge&utm_campaign=badge-trendshift-88911" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/88911/weekly?language=TypeScript" alt="Vincentwei1021%2Fvideo-shotcraft | Trendshift" width="250" height="55"/></a>
@@ -202,12 +203,6 @@ Special thanks to:
   Vlambeer's screenshake talks, classic animation timing) inform several cards.
 - **Claude Code** — this library itself was built, iterated, and QA'd with an
   AI coding agent, using the same workflow the skill teaches.
-
-## 🌏 Mirror
-
-For faster access from mainland China, this repo is also hosted on AtomGit:
-[atomgit.com/VincentWei/video-shotcraft](https://atomgit.com/VincentWei/video-shotcraft)
-(read-only mirror, auto-synced; GitHub remains the primary home).
 
 ## ⭐ Star history
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -196,6 +196,12 @@ Pitch、Miro、Superhuman、Loom** 等产品的宣传片。镜头卡记录的是
 - **Claude Code** —— 本库自身的构建、迭代与验收全程由 AI coding agent
   完成，用的正是这个 skill 所传授的工作流。
 
+## 🌏 镜像
+
+国内访问可使用 AtomGit 托管的镜像仓库：
+[atomgit.com/VincentWei/video-shotcraft](https://atomgit.com/VincentWei/video-shotcraft)
+（只读镜像，自动同步；GitHub 仍为主仓库）。
+
 ## ⭐ Star 历史
 
 <a href="https://www.star-history.com/?repos=Vincentwei1021%2Fvideo-shotcraft&type=date&legend=top-left">

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,6 +11,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/Vincentwei1021/video-shotcraft)](https://github.com/Vincentwei1021/video-shotcraft/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/Vincentwei1021/video-shotcraft)](https://github.com/Vincentwei1021/video-shotcraft/network/members)
 [![Gallery](https://img.shields.io/badge/Gallery-在线样片-d3923c)](https://vincentwei1021.github.io/video-shotcraft/)
+[![AtomGit Star](https://atomgit.com/VincentWei/video-shotcraft/star/badge.svg)](https://atomgit.com/VincentWei/video-shotcraft)
 
 <a href="https://trendshift.io/repositories/88911?utm_source=trendshift-badge&utm_medium=badge&utm_campaign=badge-trendshift-88911" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/88911/daily?language=TypeScript" alt="Vincentwei1021%2Fvideo-shotcraft | Trendshift" width="250" height="55"/></a>
 <a href="https://trendshift.io/repositories/88911?utm_source=trendshift-badge&utm_medium=badge&utm_campaign=badge-trendshift-88911" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/88911/weekly?language=TypeScript" alt="Vincentwei1021%2Fvideo-shotcraft | Trendshift" width="250" height="55"/></a>
@@ -195,12 +196,6 @@ Pitch、Miro、Superhuman、Loom** 等产品的宣传片。镜头卡记录的是
   经典动画时序原则），多张镜头卡受其启发。
 - **Claude Code** —— 本库自身的构建、迭代与验收全程由 AI coding agent
   完成，用的正是这个 skill 所传授的工作流。
-
-## 🌏 镜像
-
-国内访问可使用 AtomGit 托管的镜像仓库：
-[atomgit.com/VincentWei/video-shotcraft](https://atomgit.com/VincentWei/video-shotcraft)
-（只读镜像，自动同步；GitHub 仍为主仓库）。
 
 ## ⭐ Star 历史
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -11,6 +11,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/Vincentwei1021/video-shotcraft)](https://github.com/Vincentwei1021/video-shotcraft/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/Vincentwei1021/video-shotcraft)](https://github.com/Vincentwei1021/video-shotcraft/network/members)
 [![Gallery](https://img.shields.io/badge/Gallery-live%20previews-d3923c)](https://vincentwei1021.github.io/video-shotcraft/)
+[![AtomGit Star](https://atomgit.com/VincentWei/video-shotcraft/star/badge.svg)](https://atomgit.com/VincentWei/video-shotcraft)
 
 <a href="https://trendshift.io/repositories/88911?utm_source=trendshift-badge&utm_medium=badge&utm_campaign=badge-trendshift-88911" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/88911/daily?language=TypeScript" alt="Vincentwei1021%2Fvideo-shotcraft | Trendshift" width="250" height="55"/></a>
 <a href="https://trendshift.io/repositories/88911?utm_source=trendshift-badge&utm_medium=badge&utm_campaign=badge-trendshift-88911" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/88911/weekly?language=TypeScript" alt="Vincentwei1021%2Fvideo-shotcraft | Trendshift" width="250" height="55"/></a>
@@ -204,12 +205,6 @@ Figma、Framer、Bear、Raycast、Pitch、Miro、Superhuman、Loom** のプロ�
   （Vlambeer のスクリーンシェイクに関する講演、古典的なアニメーションのタイミングなど）。
 - **Claude Code** — このライブラリ自体も、スキルが教えるものと同じワークフローを使い、
   AI コーディングエージェントによって構築、反復改善、QA されました。
-
-## 🌏 ミラー
-
-中国本土からのアクセス向けに、AtomGit 上のミラーリポジトリも利用できます：
-[atomgit.com/VincentWei/video-shotcraft](https://atomgit.com/VincentWei/video-shotcraft)
-（読み取り専用ミラー、自動同期。GitHub がプライマリです）。
 
 ## ⭐ Star 履歴
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -205,6 +205,12 @@ Figma、Framer、Bear、Raycast、Pitch、Miro、Superhuman、Loom** のプロ�
 - **Claude Code** — このライブラリ自体も、スキルが教えるものと同じワークフローを使い、
   AI コーディングエージェントによって構築、反復改善、QA されました。
 
+## 🌏 ミラー
+
+中国本土からのアクセス向けに、AtomGit 上のミラーリポジトリも利用できます：
+[atomgit.com/VincentWei/video-shotcraft](https://atomgit.com/VincentWei/video-shotcraft)
+（読み取り専用ミラー、自動同期。GitHub がプライマリです）。
+
 ## ⭐ Star 履歴
 
 <a href="https://www.star-history.com/?repos=Vincentwei1021%2Fvideo-shotcraft&type=date&legend=top-left">


### PR DESCRIPTION
## 背景

项目已镜像入驻 AtomGit（Pull 单向自动同步，GitHub 仍为主仓）。G-Star 认证要求 README 有 AtomGit 官方露出，采用官方 badge 库（GitCode/AtomGit_Badge）中扁平样式的 Star Badge。

## 改动

- README.md / README_CN.md / README_JA.md 首屏徽章行：在 shields.io 徽章后追加 AtomGit 扁平 Star 徽章（20px 高，与 shields 同排等高），链到 AtomGit 镜像仓库。
- 不使用大尺寸 G-Star 铭牌（125×54），不加正文镜像小节（第一版的文案已回退）。

## 效果

徽章实测渲染正常（红色 G logo + Star 计数，读的是 AtomGit 侧数据）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)