### PR TITLE
docs: SKILL.md 补充 demos 的 @remotion/motion-blur 依赖说明

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -195,7 +195,9 @@ SFX；只有完整分镜确认后才进入最终素材采集。用户从 Gallery
   长样本与轻音素材各有名单需特殊处理（sound-design 4.1）。
 - `demos/` 各卡实现源码：多数为自包含灰阶 demo（部分 import
   `demos/_fixtures/Fixtures.tsx` 的假 UI 场景件，个别 import
-  `demos/_textures/` 的真实页面纹理），copy 进 Remotion 项目即可跑。
+  `demos/_textures/` 的真实页面纹理），copy 进 Remotion 项目即可跑；
+  个别 demo 用到 `@remotion/motion-blur`（CameraMotionBlur），需
+  `npm i @remotion/motion-blur`，名单见 `demos/README.md`。
 - `template/` 完整可渲染工程：`npm install && npx remotion render
   src/index.ts AiflPromo out/promo.mp4`。
 - `gallery/` 静态画廊：优先直接给用户在线版


### PR DESCRIPTION
## 问题

`SKILL.md` 的「资产使用方式」里，`demos/` 一条写的是「copy 进 Remotion 项目即可跑」，并且特意标注了 `_fixtures/` 和 `_textures/` 两个前置条件，但没提 `@remotion/motion-blur`。

实际有 8 个 demo import 了它，而它不是 Remotion 的基础依赖：

- `demos/camera/crash-zoom-punch/CrashZoomReal.tsx`
- `demos/camera/crash-zoom-punch/CrashImpactReal.tsx`
- `demos/camera/space-camera-moves/DroneDiveLanding.tsx`
- `demos/opening/magician-card-flourish/MagicianCardFlourish.tsx`
- `demos/rhythm/speed-ramp-freeze/SpeedRampReal.tsx`
- `demos/transition/shot-transitions/WhipPanReal.tsx`
- `demos/transition/shot-transitions/WhipBrakeReal.tsx`
- `demos/transition/transition-hidden-cut/InvisibleCut.tsx`

对应 6 张卡：`crash-zoom-punch`、`space-camera-moves`、`magician-card-flourish`、`speed-ramp-freeze`、`shot-transitions`、`transition-hidden-cut`。这 6 张卡本身也没写这条依赖。

`demos/README.md:18` 已经写清楚了（`npm i @remotion/motion-blur`），但「何时读哪个文件」表里「逐镜头实现」一行是：

> 该镜头卡全文 + 按“参考实现”定位的准确 demo 源码全文 + assets/lib/ 对应组件

按这条路线走的 agent 不会读到 `demos/README.md`，copy 完源码直接 module not found。

## 改动

在 `demos/` 一条后面补一句，指回 `demos/README.md` 的名单。写法对齐同一节里 `assets/lib/` 已有的依赖声明（FlatPanel 与 helpers/camera 需要 `three` + `@react-three/fiber` + `@remotion/three`）。

只动 `SKILL.md` 一处。`demos/README.md` 本来就是对的，没动。

## 备注

与 #27 无冲突：#27 改的是 `SKILL.md` 的 5–8 行和 201–205 行，这里改的是 196–198 行。