### PR TITLE
fix: 老卡 demo 的 SVG 固定 ID 全部改 useId 实例派生（13 文件）

### DIFF
--- a/demos/camera/steep-tilt-glide/SteepTiltGlide.tsx
+++ b/demos/camera/steep-tilt-glide/SteepTiltGlide.tsx
@@ -6,7 +6,7 @@
 // perspective / perspectiveOrigin / rotateY / rotateZ 全程一个常数不动，
 // 动的只有页面自身沿其 3D 平面横向（局部 X 轴）的滑移 translateX。
 // v4 的悬空贴落（FloatWrap 同形软影）保留。
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, interpolate, useCurrentFrame, Easing } from 'remotion';
 
 const FONT = 'Helvetica, Arial, sans-serif';
@@ -38,22 +38,26 @@ const liftOf = (t: number, land: number, H = 230) => {
 };
 
 /* ClickUp 彩色小 logo（双 V 叠形近似） */
-const CULogo: React.FC<{ size: number }> = ({ size }) => (
-  <svg width={size} height={size} viewBox="0 0 100 100">
-    <defs>
-      <linearGradient id="cu1" x1="0" y1="0" x2="1" y2="0">
-        <stop offset="0" stopColor="#8930fd" />
-        <stop offset="1" stopColor="#49ccf9" />
-      </linearGradient>
-      <linearGradient id="cu2" x1="0" y1="0" x2="1" y2="0">
-        <stop offset="0" stopColor="#ff02f0" />
-        <stop offset="1" stopColor="#ffc800" />
-      </linearGradient>
-    </defs>
-    <path d="M 14 62 L 50 30 L 86 62" fill="none" stroke="url(#cu1)" strokeWidth="16" strokeLinecap="round" strokeLinejoin="round" />
-    <path d="M 22 84 L 50 62 L 78 84" fill="none" stroke="url(#cu2)" strokeWidth="16" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
+const CULogo: React.FC<{ size: number }> = ({ size }) => {
+  // 渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 100">
+      <defs>
+        <linearGradient id={`cu1-${uid}`} x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stopColor="#8930fd" />
+          <stop offset="1" stopColor="#49ccf9" />
+        </linearGradient>
+        <linearGradient id={`cu2-${uid}`} x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stopColor="#ff02f0" />
+          <stop offset="1" stopColor="#ffc800" />
+        </linearGradient>
+      </defs>
+      <path d="M 14 62 L 50 30 L 86 62" fill="none" stroke={`url(#cu1-${uid})`} strokeWidth="16" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M 22 84 L 50 62 L 78 84" fill="none" stroke={`url(#cu2-${uid})`} strokeWidth="16" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
 
 /* Dropbox 蓝四菱形 glyph（原片 f45/f60 主区圆角灰砖里的图标） */
 const DropboxGlyph: React.FC<{ size: number }> = ({ size }) => (

--- a/demos/effects/glow-flyline-moves/FlylineArc.tsx
+++ b/demos/effects/glow-flyline-moves/FlylineArc.tsx
@@ -3,7 +3,7 @@
 // "打"过去(22f, out-cubic 生长)，亮点头部领跑、亮头暗尾拖尾；到达帧目标卡
 // 3px+ ink 描边脉冲 + 加深脉冲(白底禁提亮)。随后第二条线接力打到上中卡。
 // 收尾真静止：全部动画在 f86 前结束，之后所有元素冻结。
-import React from 'react';
+import React, { useId } from 'react';
 import { useCurrentFrame, interpolate, Easing } from 'remotion';
 import { FakeDashboard } from '../../_fixtures/Fixtures';
 
@@ -29,8 +29,9 @@ const CARD_TM = { x: 808, y: 108, w: 524, h: 454, cx: 1070, cy: 335 }; // 上中
 const Flyline: React.FC<{
   frame: number;
   start: number; // 生长起始帧
+  haloId: string; // 光头径向渐变 ID（父组件按实例生成）
   p0: Pt; p1: Pt; p2: Pt; p3: Pt;
-}> = ({ frame, start, p0, p1, p2, p3 }) => {
+}> = ({ frame, start, haloId, p0, p1, p2, p3 }) => {
   const DUR = 22;
   if (frame < start) return null;
   const e = interpolate(frame, [start, start + DUR], [0, 1], {
@@ -82,7 +83,7 @@ const Flyline: React.FC<{
       {/* 光头：仅生长期挂载，摘罩即真静止 */}
       {growing && (
         <g>
-          <circle cx={head.x} cy={head.y} r={26} fill="url(#headHalo)" />
+          <circle cx={head.x} cy={head.y} r={26} fill={`url(#${haloId})`} />
           <circle cx={head.x} cy={head.y} r={9} fill="#ffffff" stroke="#2f2f2f" strokeWidth={3} />
         </g>
       )}
@@ -125,6 +126,8 @@ const CardPulse: React.FC<{
 
 export const FlylineArc: React.FC = () => {
   const frame = useCurrentFrame();
+  // 渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const haloId = `headHalo-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
 
   // 时间轴：线1 生长 10–32f → 卡RB脉冲 32–50f；线2 生长 46–68f → 卡TM脉冲 68–86f
   // f86 后全静止（140f 总长 → 静止 54f ≥ 35f）
@@ -142,7 +145,7 @@ export const FlylineArc: React.FC = () => {
         style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none' }}
       >
         <defs>
-          <radialGradient id="headHalo">
+          <radialGradient id={haloId}>
             <stop offset="0%" stopColor="rgba(0,0,0,0.38)" />
             <stop offset="55%" stopColor="rgba(0,0,0,0.18)" />
             <stop offset="100%" stopColor="rgba(0,0,0,0)" />
@@ -150,8 +153,8 @@ export const FlylineArc: React.FC = () => {
         </defs>
         <CardPulse frame={frame} at={32} rect={CARD_RB} />
         <CardPulse frame={frame} at={68} rect={CARD_TM} />
-        <Flyline frame={frame} start={10} {...L1} />
-        <Flyline frame={frame} start={46} {...L2} />
+        <Flyline frame={frame} start={10} haloId={haloId} {...L1} />
+        <Flyline frame={frame} start={46} haloId={haloId} {...L2} />
       </svg>
     </div>
   );

--- a/demos/effects/glow-flyline-moves/OrbFlylineRelay.tsx
+++ b/demos/effects/glow-flyline-moves/OrbFlylineRelay.tsx
@@ -5,7 +5,7 @@
 // (opacity→1 + 描边亮白脉冲) 且邻近光斑同帧涨亮一拍（组合共振证明点）；
 // 线二 B→C 接力，C 亮起收束。光斑 95–120f out-sine 减速收敛，
 // 全部动画 f120 前结束，末 35f 真静止。
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, interpolate, useCurrentFrame, Easing } from 'remotion';
 
 // 库内标准伪随机（帧确定）
@@ -82,8 +82,9 @@ const surge = (frame: number, at: number) => {
 const Flyline: React.FC<{
   frame: number;
   start: number; // 生长起始帧
+  haloId: string; // 光头径向渐变 ID（父组件按实例生成）
   p0: Pt; p1: Pt; p2: Pt; p3: Pt;
-}> = ({ frame, start, p0, p1, p2, p3 }) => {
+}> = ({ frame, start, haloId, p0, p1, p2, p3 }) => {
   const DUR = 24;      // 生长
   const HOLD = 4;      // 到达后停一拍
   const FADE = 14;     // 消散（线性，帧时间解耦）
@@ -136,7 +137,7 @@ const Flyline: React.FC<{
       {/* 亮点头领跑：仅生长期挂载 */}
       {growing && (
         <g>
-          <circle cx={head.x} cy={head.y} r={34} fill="url(#orbHeadHalo)" />
+          <circle cx={head.x} cy={head.y} r={34} fill={`url(#${haloId})`} />
           <circle cx={head.x} cy={head.y} r={8} fill="#ffffff" />
         </g>
       )}
@@ -193,6 +194,8 @@ const DarkCard: React.FC<{
 
 export const OrbFlylineRelay: React.FC = () => {
   const frame = useCurrentFrame();
+  // 渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const haloId = `orbHeadHalo-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
 
   // 光斑有效时间：0–95f 匀速漂移，95–120f out-sine 减速收敛，f≥120 恒定 → 末 35f 真静止
   const t =
@@ -254,14 +257,14 @@ export const OrbFlylineRelay: React.FC = () => {
         style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none' }}
       >
         <defs>
-          <radialGradient id="orbHeadHalo">
+          <radialGradient id={haloId}>
             <stop offset="0%" stopColor="rgba(255,255,255,0.55)" />
             <stop offset="55%" stopColor="rgba(255,255,255,0.22)" />
             <stop offset="100%" stopColor="rgba(255,255,255,0)" />
           </radialGradient>
         </defs>
-        <Flyline frame={frame} start={18} {...L1} />
-        <Flyline frame={frame} start={52} {...L2} />
+        <Flyline frame={frame} start={18} haloId={haloId} {...L1} />
+        <Flyline frame={frame} start={52} haloId={haloId} {...L2} />
       </svg>
     </AbsoluteFill>
   );

--- a/demos/effects/line-boil/LineBoil.tsx
+++ b/demos/effects/line-boil/LineBoil.tsx
@@ -7,7 +7,7 @@
 // 105f 起逐帧完全相同，真静止 ≥35f。
 // 关键帧：0–35 完全静止(boil off) → 35–105 沸腾(boil on, seed 每 3 帧一换)
 // → 105 摘罩 → 105–140 真静止(boil off)。
-import React from 'react';
+import React, { useId } from 'react';
 import { useCurrentFrame, interpolate } from 'remotion';
 import { G, TitleBlock } from '../../_fixtures/Fixtures';
 
@@ -39,6 +39,8 @@ const CornerTag: React.FC<{ text: string; opacity: number }> = ({ text, opacity 
 
 export const LineBoil: React.FC = () => {
   const f = useCurrentFrame();
+  // 滤镜 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const boilId = `boil-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
   const boiling = f >= BOIL_START && f < BOIL_END;
   // seed 每 3 帧阶梯换 → 8~10Hz 的手绘颤动感；帧确定，无随机源
   const seed = Math.floor(f / 3);
@@ -57,7 +59,7 @@ export const LineBoil: React.FC = () => {
       {boiling && (
         <svg width={0} height={0} style={{ position: 'absolute' }}>
           <defs>
-            <filter id="boil" x="-15%" y="-15%" width="130%" height="130%">
+            <filter id={boilId} x="-15%" y="-15%" width="130%" height="130%">
               <feTurbulence
                 type="fractalNoise"
                 baseFrequency={0.015}
@@ -92,7 +94,7 @@ export const LineBoil: React.FC = () => {
           alignItems: 'center',
           justifyContent: 'center',
           gap: 56,
-          filter: boiling ? 'url(#boil)' : undefined,
+          filter: boiling ? `url(#${boilId})` : undefined,
         }}
       >
         <div

--- a/demos/opening/magician-card-flourish/MagicianCardFlourish.tsx
+++ b/demos/opening/magician-card-flourish/MagicianCardFlourish.tsx
@@ -9,7 +9,7 @@
 // ③ 弹射出场：slow-in → burst → decelerating arc（起飞先慢速蓄力挤出，
 //    急加速弹射，弧线段整体减速抵达中心硬定格）。
 // v5 其余保留：中心极远飞出+13 圈自旋+94% 定格+sheen 扫光。总长 141 帧。
-import React from 'react';
+import React, { useId } from 'react';
 import { useCurrentFrame, interpolate, Easing } from 'remotion';
 import { CameraMotionBlur } from '@remotion/motion-blur';
 import { G } from '../../_fixtures/Fixtures';
@@ -84,6 +84,9 @@ const CardBack: React.FC = () => (
 // ⑤ 背景纯黑，光束边缘干净锐利（真实衍射，无宽糊外层）。
 // 时长 0.5s：渐亮（f0–4）→ 全芒微闪（f4–10）→ 坍缩（f10–15）。
 const SpawnFlash: React.FC<{ f: number }> = ({ f }) => {
+  // 渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  // hooks 必须在条件 return 之前调用
+  const SPIKE_ID = `mcf-needle-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
   if (f > FLASH_END) return null;
   const grow = interpolate(f, [0, 2.5], [0.2, 1], {
     extrapolateRight: 'clamp', easing: Easing.out(Easing.quad),
@@ -101,7 +104,6 @@ const SpawnFlash: React.FC<{ f: number }> = ({ f }) => {
   const rot = interpolate(f, [0, FLASH_END], [0, 90], { extrapolateRight: 'clamp', easing: Easing.inOut(Easing.quad) });
   // 针状光束：极细楔形（根部窄、尖端归零）+ 亮度指数渐隐——对照参考图
   // v9（批次 18）：用户意见"开场光点的光芒要旋转90度"——整体转 90°：长轴 -38°→52°（陡斜近竖贯），短轴 52°→142°
-  const SPIKE_ID = 'mcf-needle';
   const needle = (deg: number, len: number, w0: number, op: number) => (
     <g key={`${deg}-${len}`} transform={`rotate(${deg})`} opacity={op}>
       <path d={`M 0 ${-w0 / 2} L ${len} 0 L 0 ${w0 / 2} Z`} fill={`url(#${SPIKE_ID})`} />

--- a/demos/rhythm/speed-ramp-freeze/FreezeAnnotateReal.tsx
+++ b/demos/rhythm/speed-ramp-freeze/FreezeAnnotateReal.tsx
@@ -1,6 +1,7 @@
 // freeze-annotate 定格标注（轮 G）——真实卡片流运动中定格，
 // 马克笔琥珀圈注（feTurbulence 手绘抖动）圈住目标卡 + 箭头点题，解冻继续。
 // remap：0–45 流动 → 45–100 定格（斜率0）→ 100–135 解冻（1.4x 补偿）。
+import { useId } from 'react';
 import { AbsoluteFill, Img, interpolate, staticFile, useCurrentFrame } from 'remotion';
 import layout from '../../_textures/live-layout.json';
 
@@ -14,6 +15,8 @@ const AMBER = '#b45309';
 
 export const FreezeAnnotateReal: React.FC = () => {
   const frame = useCurrentFrame();
+  // 滤镜 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const roughId = `rough-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
   const src = interpolate(frame, [0, 45, 100, 135], [0, 45, 45, 94], {
     extrapolateLeft: 'clamp', extrapolateRight: 'clamp',
   });
@@ -46,7 +49,7 @@ export const FreezeAnnotateReal: React.FC = () => {
       </div>
       <svg width={1920} height={1080} style={{ position: 'absolute', inset: 0, pointerEvents: 'none', opacity: fade }}>
         <defs>
-          <filter id="rough">
+          <filter id={roughId}>
             <feTurbulence type="fractalNoise" baseFrequency="0.02" numOctaves="2" seed="7" result="n" />
             <feDisplacementMap in="SourceGraphic" in2="n" scale="7" />
           </filter>
@@ -56,13 +59,13 @@ export const FreezeAnnotateReal: React.FC = () => {
           fill="none" stroke={AMBER} strokeWidth={8} strokeLinecap="round"
           strokeDasharray={C} strokeDashoffset={C * (1 - draw)}
           transform={`rotate(-6 ${targetX} 560)`}
-          filter="url(#rough)"
+          filter={`url(#${roughId})`}
         />
         <path
           d={`M ${targetX + 330} 190 Q ${targetX + 220} 240 ${targetX + 140} 320`}
           fill="none" stroke={AMBER} strokeWidth={8} strokeLinecap="round"
           strokeDasharray={420} strokeDashoffset={420 * (1 - arrowDraw)}
-          filter="url(#rough)"
+          filter={`url(#${roughId})`}
         />
       </svg>
     </AbsoluteFill>

--- a/demos/transition/card-flock-tumble/CardFlockTumble.tsx
+++ b/demos/transition/card-flock-tumble/CardFlockTumble.tsx
@@ -6,7 +6,7 @@
 //    原片是单个湍流烟雾环——边缘破碎起絮、环身明暗斑块交错、粉紫为主
 //    顶部偏奶桃色、出现后减速外扩且全程缓慢长大、衰减极慢（片尾仍在，
 //    弥散变淡而非熄灭）、中心无水面光。用 feTurbulence+位移贴图模拟。
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, useCurrentFrame, interpolate, Easing } from 'remotion';
 
 const mulberry32 = (a: number) => () => {
@@ -134,6 +134,9 @@ const UiCard: React.FC<{ seed: number; title: string }> = ({ seed, title }) => (
 // 粉紫为主、顶部奶桃色；出现后减速外扩且全程缓慢长大；衰减极慢——
 // 片尾仍清晰可见（弥散变淡而非熄灭）；中心无水面光、背景纯黑。
 const SmokeRing: React.FC<{ frame: number }> = ({ frame }) => {
+  // 滤镜/渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  // hooks 必须在条件 return 之前调用
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const t = frame - RING_T0;
   if (t < 0) return null;
   // 半径：小出现→减速外扩，之后仍缓慢长大（原片全程未停）
@@ -151,22 +154,22 @@ const SmokeRing: React.FC<{ frame: number }> = ({ frame }) => {
       <svg width={1920} height={1080} viewBox="0 0 1920 1080" style={{ position: 'absolute', inset: 0, overflow: 'visible' }}>
         <defs>
           {/* 破碎絮状边缘：分形噪声位移主体（octaves=4 → 更细的絮丝） */}
-          <filter id="smokeA" x="-60%" y="-60%" width="220%" height="220%">
+          <filter id={`smokeA-${uid}`} x="-60%" y="-60%" width="220%" height="220%">
             <feTurbulence type="fractalNoise" baseFrequency="0.013 0.016" numOctaves={4} seed={11} result="n" />
             <feDisplacementMap in="SourceGraphic" in2="n" scale={disp} xChannelSelector="R" yChannelSelector="G" />
           </filter>
           {/* 第二组噪声（不同种子）：亮斑错位层 */}
-          <filter id="smokeB" x="-60%" y="-60%" width="220%" height="220%">
+          <filter id={`smokeB-${uid}`} x="-60%" y="-60%" width="220%" height="220%">
             <feTurbulence type="fractalNoise" baseFrequency="0.021 0.018" numOctaves={4} seed={37} result="n" />
             <feDisplacementMap in="SourceGraphic" in2="n" scale={disp * 0.85} xChannelSelector="R" yChannelSelector="G" />
           </filter>
           {/* 第三组噪声：暗斑洞隙层（压出环身明暗交错的黑斑） */}
-          <filter id="smokeC" x="-60%" y="-60%" width="220%" height="220%">
+          <filter id={`smokeC-${uid}`} x="-60%" y="-60%" width="220%" height="220%">
             <feTurbulence type="fractalNoise" baseFrequency="0.019 0.023" numOctaves={3} seed={73} result="n" />
             <feDisplacementMap in="SourceGraphic" in2="n" scale={disp * 1.1} xChannelSelector="R" yChannelSelector="G" />
           </filter>
           {/* 顶部奶桃色、下部粉紫的环身渐变（降饱和，对照原片灰粉调） */}
-          <linearGradient id="ringGrad" x1="0" y1="0" x2="0" y2="1">
+          <linearGradient id={`ringGrad-${uid}`} x1="0" y1="0" x2="0" y2="1">
             <stop offset="0%" stopColor="hsla(28 45% 78% / 0.85)" />
             <stop offset="35%" stopColor="hsla(315 45% 74% / 0.85)" />
             <stop offset="100%" stopColor="hsla(276 42% 66% / 0.85)" />
@@ -174,19 +177,19 @@ const SmokeRing: React.FC<{ frame: number }> = ({ frame }) => {
         </defs>
         <g transform={`rotate(${rot} 960 540)`} opacity={op}>
           {/* 外圈弥散柔光 */}
-          <g style={{ filter: 'url(#smokeA)' }}>
+          <g style={{ filter: `url(#smokeA-${uid})` }}>
             <circle cx={960} cy={540} r={R} fill="none" stroke="hsla(295 40% 68% / 0.26)" strokeWidth={w * 1.9} style={{ filter: 'blur(22px)' }} />
           </g>
           {/* 环身主体（湍流位移 → 破碎絮状边缘；blur 收小保留湍流纹理） */}
-          <g style={{ filter: 'url(#smokeA)' }}>
-            <circle cx={960} cy={540} r={R} fill="none" stroke="url(#ringGrad)" strokeWidth={w} style={{ filter: 'blur(9px)' }} opacity={0.85} />
+          <g style={{ filter: `url(#smokeA-${uid})` }}>
+            <circle cx={960} cy={540} r={R} fill="none" stroke={`url(#ringGrad-${uid})`} strokeWidth={w} style={{ filter: 'blur(9px)' }} opacity={0.85} />
           </g>
           {/* 亮斑层：另一组噪声错位叠加 */}
-          <g style={{ filter: 'url(#smokeB)' }}>
+          <g style={{ filter: `url(#smokeB-${uid})` }}>
             <circle cx={960} cy={540} r={R * 0.99} fill="none" stroke="hsla(310 60% 86% / 0.6)" strokeWidth={w * 0.45} style={{ filter: 'blur(6px)' }} />
           </g>
           {/* 暗斑洞隙：第三组噪声轻压环身 → 明暗斑块交错（轻微，勿成迷彩） */}
-          <g style={{ filter: 'url(#smokeC)' }}>
+          <g style={{ filter: `url(#smokeC-${uid})` }}>
             <circle cx={960} cy={540} r={R * 1.005} fill="none" stroke="hsla(262 40% 10% / 0.32)" strokeWidth={w * 0.4} style={{ filter: 'blur(7px)' }} />
           </g>
         </g>
@@ -266,6 +269,8 @@ const lerpPose = (a: Pose, b: Pose, t: number): Pose => {
 
 export const CardFlockTumble: React.FC = () => {
   const frame = useCurrentFrame();
+  // 渐变 ID 按实例生成，多实例同场不串引
+  const gradId = `strokeGrad-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
 
   // STRONGER 巨字
   const st = frame - TEXT_T0;
@@ -352,7 +357,7 @@ export const CardFlockTumble: React.FC = () => {
             }}
           >
             <defs>
-              <linearGradient id="strokeGrad" x1="0" y1="0" x2="1" y2="0">
+              <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="0">
                 <stop offset="0%" stopColor="#ffe14d" />
                 <stop offset="30%" stopColor="#ff5ad0" />
                 <stop offset="60%" stopColor="#b46bff" />
@@ -369,7 +374,7 @@ export const CardFlockTumble: React.FC = () => {
               fontSize={352}
               letterSpacing={2}
               fill="none"
-              stroke="url(#strokeGrad)"
+              stroke={`url(#${gradId})`}
               strokeWidth={4.5}
             >
               STRONGER

--- a/demos/transition/print-texture-transitions/InkBleedReveal.tsx
+++ b/demos/transition/print-texture-transitions/InkBleedReveal.tsx
@@ -6,12 +6,16 @@
 // mask 形状上，新景内容始终清晰。帧 0–20 hold 旧景；帧 20–98 半径
 // 0→1450（Easing.out(quad)）再叠 ±8% 低频正弦扰动（帧 78–98 扰动衰减到 0，
 // 洇满全屏）；帧 100–130 摘掉 mask 直接铺新景，真静止 30f。
-import React from 'react';
+import React, { useId } from 'react';
 import { useCurrentFrame, interpolate, Easing } from 'remotion';
 import { G, FakeDashboard, TitleBlock } from '../../_fixtures/Fixtures';
 
 export const InkBleedReveal: React.FC = () => {
   const frame = useCurrentFrame();
+  // 滤镜/mask ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const bleedId = `inkBleed-${uid}`;
+  const maskId = `inkMask-${uid}`;
 
   // 墨滴落点：画面中心偏左上
   const cx = 800;
@@ -60,16 +64,16 @@ export const InkBleedReveal: React.FC = () => {
         >
           <defs>
             {/* filter 只挂在 mask 的圆上——揉的是遮罩边，不是画面内容 */}
-            <filter id="inkBleed" x="-40%" y="-40%" width="180%" height="180%">
+            <filter id={bleedId} x="-40%" y="-40%" width="180%" height="180%">
               <feTurbulence type="fractalNoise" baseFrequency="0.02" numOctaves="3" seed="7" result="noise" />
               <feDisplacementMap in="SourceGraphic" in2="noise" scale={dispScale} xChannelSelector="R" yChannelSelector="G" />
             </filter>
-            <mask id="inkMask" maskUnits="userSpaceOnUse" x="0" y="0" width="1920" height="1080">
+            <mask id={maskId} maskUnits="userSpaceOnUse" x="0" y="0" width="1920" height="1080">
               <rect x="0" y="0" width="1920" height="1080" fill="black" />
-              {r > 0.5 && <circle cx={cx} cy={cy} r={r} fill="white" filter="url(#inkBleed)" />}
+              {r > 0.5 && <circle cx={cx} cy={cy} r={r} fill="white" filter={`url(#${bleedId})`} />}
             </mask>
           </defs>
-          <g mask="url(#inkMask)">
+          <g mask={`url(#${maskId})`}>
             <foreignObject x="0" y="0" width="1920" height="1080">
               <FakeDashboard variant="A" />
             </foreignObject>

--- a/demos/transition/transition-travel/LetterformZoom.tsx
+++ b/demos/transition/transition-travel/LetterformZoom.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from 'remotion';
 import { FakeDashboard, G } from '../../_fixtures/Fixtures';
 
@@ -25,6 +25,8 @@ const titleFont: React.CSSProperties = {
 
 export const LetterformZoom: React.FC = () => {
   const frame = useCurrentFrame();
+  // mask ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const cutId = `lfz-cut-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
 
   // 0–25f 建立 hold；25–85f 推进。慢起 bezier 叠指数尺度 = 前段慢、后段陡
   const t = interpolate(frame, [25, 85], [0, 1], {
@@ -91,7 +93,7 @@ export const LetterformZoom: React.FC = () => {
             style={{ position: 'absolute', inset: 0, display: 'block' }}
           >
             <defs>
-              <mask id="lfz-cut">
+              <mask id={cutId}>
                 <rect width={1920} height={1080} fill="#fff" />
                 <text
                   x={960}
@@ -104,7 +106,7 @@ export const LetterformZoom: React.FC = () => {
                 </text>
               </mask>
             </defs>
-            <rect width={1920} height={1080} fill={G.bg} mask="url(#lfz-cut)" />
+            <rect width={1920} height={1080} fill={G.bg} mask={`url(#${cutId})`} />
             {/* 字缘细描边：让"洞"的轮廓在米灰上读得清 */}
             <text
               x={960}

--- a/demos/typography/marker-underline-title/MarkerUnderlineTitle.tsx
+++ b/demos/typography/marker-underline-title/MarkerUnderlineTitle.tsx
@@ -1,7 +1,7 @@
 // marker-underline-title —— 白底大标题落定后，斜体 "new" 下方一道
 // 马克笔下划线从左到右描画（粗细变化/端头圆润/微歪/边缘毛糙）。
 // 对标 notion-ai.mp4 2.3–3.6s。与库内 draw-svg-trace 撞车，本版做马克笔质感。
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, interpolate, useCurrentFrame } from 'remotion';
 
 const mulberry32 = (a: number) => () => {
@@ -35,6 +35,8 @@ const buildStroke = (len: number, seed: number) => {
 
 export const MarkerUnderlineTitle: React.FC = () => {
   const frame = useCurrentFrame();
+  // clipPath ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const revealId = `reveal-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
   const LEN = 252;
 
   // 标题落定：整块从下方 30px 弹入（ease-out），24 帧内完成
@@ -70,12 +72,12 @@ export const MarkerUnderlineTitle: React.FC = () => {
               style={{ position: 'absolute', left: -12, bottom: -20, overflow: 'visible' }}
             >
               <defs>
-                <clipPath id="reveal">
+                <clipPath id={revealId}>
                   <rect x={0} y={-20} width={drawE * (LEN + 6)} height={60} />
                 </clipPath>
               </defs>
               {draw > 0 && (
-                <path d={path} fill="#111111" clipPath="url(#reveal)" />
+                <path d={path} fill="#111111" clipPath={`url(#${revealId})`} />
               )}
             </svg>
           </span>

--- a/demos/ui-entrance/integration-hub-map/IntegrationHubMap.tsx
+++ b/demos/ui-entrance/integration-hub-map/IntegrationHubMap.tsx
@@ -12,7 +12,7 @@
 //    循环流动，直到片尾不停。
 // 运动结构对照截图：S1 近景正视可读 → S2 翻转中+拉远+泛光起 →
 // S3/S4 侧棱白热爆发+图标浮现 → S5/S6 新页转正、光管连入 → S7/S8 稳定输送。
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, useCurrentFrame, interpolate, Easing } from 'remotion';
 
 const mulberry32 = (a: number) => () => {
@@ -244,6 +244,8 @@ const RECTS = Array.from({ length: 9 }, (_, i) => ({
 
 export const IntegrationHubMap: React.FC = () => {
   const frame = useCurrentFrame();
+  // 滤镜/渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
 
   // --- 相机/面板轨迹：近景正视旧页 → 整体翻转 180°（翻到背面=新页）+ 拉远落定 ---
   const zoom = interpolate(frame, [0, 14, 58, 96], [2.05, 1.95, 1.1, 1.0], {
@@ -328,7 +330,7 @@ export const IntegrationHubMap: React.FC = () => {
             const [x1, y1] = [nums[0], nums[1]];
             const [x2, y2] = [nums[nums.length - 2], nums[nums.length - 1]];
             return (
-              <linearGradient key={i} id={`rainbow-${i}`} gradientUnits="userSpaceOnUse" x1={x1} y1={y1} x2={x2} y2={y2}>
+              <linearGradient key={i} id={`rainbow-${uid}-${i}`} gradientUnits="userSpaceOnUse" x1={x1} y1={y1} x2={x2} y2={y2}>
                 <stop offset="0%" stopColor="#ffe14d" />
                 <stop offset="28%" stopColor="#ff8a5a" />
                 <stop offset="52%" stopColor="#ff5ad0" />
@@ -339,7 +341,7 @@ export const IntegrationHubMap: React.FC = () => {
           })}
           {/* userSpaceOnUse：纯水平/垂直直线管的 bbox 为零，百分比滤镜区域会
               坍缩成 0 导致整条管不渲染（github/salesforce/dropbox 三管消失） */}
-          <filter id="pipeGlow" filterUnits="userSpaceOnUse" x="0" y="0" width="1920" height="1080">
+          <filter id={`pipeGlow-${uid}`} filterUnits="userSpaceOnUse" x="0" y="0" width="1920" height="1080">
             <feGaussianBlur stdDeviation="8" result="b" />
             <feMerge>
               <feMergeNode in="b" />
@@ -363,11 +365,11 @@ export const IntegrationHubMap: React.FC = () => {
             extrapolateRight: 'clamp',
           });
           return (
-            <g key={i} filter="url(#pipeGlow)">
+            <g key={i} filter={`url(#pipeGlow-${uid})`}>
               <path
                 d={p.path}
                 fill="none"
-                stroke={`url(#rainbow-${i})`}
+                stroke={`url(#rainbow-${uid}-${i})`}
                 strokeWidth={17}
                 strokeLinecap="round"
                 strokeDasharray={`${dashOn} ${p.len + 60}`}

--- a/demos/ui-entrance/neon-frame-forerun/NeonFrameForerun.tsx
+++ b/demos/ui-entrance/neon-frame-forerun/NeonFrameForerun.tsx
@@ -3,7 +3,7 @@
 // 同形软影，随页面点亮进程同步先后贴合（FloatWrap 模式，对标截图③：
 // tab/组件悬空带错位影 → ④全部贴合）。v2 已有：强透视直角框左缘中点
 // 两头奔画、面板原地由暗转亮、背景霓虹管框群中亮尾熄。
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, useCurrentFrame, interpolate, Easing } from 'remotion';
 
 const easeFall = Easing.bezier(0.5, 0.05, 0.6, 1); // 加速下落、末端软着陆
@@ -148,6 +148,8 @@ const BG_FRAMES: BgFrame[] = Array.from({ length: 18 }).map(() => ({
 
 export const NeonFrameForerun: React.FC = () => {
   const frame = useCurrentFrame();
+  // 滤镜/渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   // 主框描画：左缘中点向两头奔跑，26 帧成型（截图①→②）
   const trace = interpolate(frame, [2, 28], [0, 1], {
     extrapolateLeft: 'clamp', extrapolateRight: 'clamp',
@@ -190,7 +192,7 @@ export const NeonFrameForerun: React.FC = () => {
       {/* 背景霓虹管框群 */}
       <svg width={1920} height={1080} style={{ position: 'absolute' }}>
         <defs>
-          <filter id="bgblur" x="-60%" y="-60%" width="220%" height="220%">
+          <filter id={`bgblur-${uid}`} x="-60%" y="-60%" width="220%" height="220%">
             <feGaussianBlur stdDeviation={7} />
           </filter>
         </defs>
@@ -200,7 +202,7 @@ export const NeonFrameForerun: React.FC = () => {
           return (
             <g key={i} transform={`translate(${b.x} ${b.y}) skewY(${b.skew * 0.4}) skewX(${b.skew})`}>
               <rect width={b.w} height={b.h} rx={4} fill="none"
-                stroke={b.hue} strokeWidth={7} filter="url(#bgblur)" opacity={op * 0.8} />
+                stroke={b.hue} strokeWidth={7} filter={`url(#bgblur-${uid})`} opacity={op * 0.8} />
               <rect width={b.w} height={b.h} rx={4} fill="none"
                 stroke={b.hue} strokeWidth={2} opacity={op} />
             </g>
@@ -234,29 +236,29 @@ export const NeonFrameForerun: React.FC = () => {
           <svg width={PW + 80} height={PH + 80} viewBox={`-40 -40 ${PW + 80} ${PH + 80}`}
             style={{ position: 'absolute', left: -40, top: -40 }}>
             <defs>
-              <linearGradient id="mainfg" gradientUnits="userSpaceOnUse" x1={0} y1={0} x2={PW} y2={PH}>
+              <linearGradient id={`mainfg-${uid}`} gradientUnits="userSpaceOnUse" x1={0} y1={0} x2={PW} y2={PH}>
                 <stop offset="0%" stopColor="#c07af5" />
                 <stop offset="38%" stopColor="#e58bd8" />
                 <stop offset="72%" stopColor="#f0b06a" />
                 <stop offset="100%" stopColor="#e8925c" />
               </linearGradient>
-              <filter id="fblur" x="-40%" y="-40%" width="180%" height="180%">
+              <filter id={`fblur-${uid}`} x="-40%" y="-40%" width="180%" height="180%">
                 <feGaussianBlur stdDeviation={10} />
               </filter>
-              <filter id="fblur2" x="-40%" y="-40%" width="180%" height="180%">
+              <filter id={`fblur2-${uid}`} x="-40%" y="-40%" width="180%" height="180%">
                 <feGaussianBlur stdDeviation={3} />
               </filter>
             </defs>
             {[1, -1].map((dir) => (
               <g key={dir}>
                 {/* 糊辉光层：一直保留 */}
-                <path d={FRAME_D} pathLength={PL} fill="none" stroke="url(#mainfg)"
-                  strokeWidth={14} strokeLinecap="butt" filter="url(#fblur)"
+                <path d={FRAME_D} pathLength={PL} fill="none" stroke={`url(#mainfg-${uid})`}
+                  strokeWidth={14} strokeLinecap="butt" filter={`url(#fblur-${uid})`}
                   strokeDasharray={`${headP} ${PL}`}
                   strokeDashoffset={dir === 1 ? 0 : -(PL - headP)}
                   opacity={0.6 * rimGlow} />
                 {/* 亮芯细线：面板亮起后淡出并入 rim */}
-                <path d={FRAME_D} pathLength={PL} fill="none" stroke="url(#mainfg)"
+                <path d={FRAME_D} pathLength={PL} fill="none" stroke={`url(#mainfg-${uid})`}
                   strokeWidth={3.5} strokeLinecap="butt"
                   strokeDasharray={`${headP} ${PL}`}
                   strokeDashoffset={dir === 1 ? 0 : -(PL - headP)}
@@ -264,7 +266,7 @@ export const NeonFrameForerun: React.FC = () => {
                 {/* 奔跑亮头 */}
                 {trace < 1 && (
                   <path d={FRAME_D} pathLength={PL} fill="none" stroke="#ffffff"
-                    strokeWidth={6} strokeLinecap="round" filter="url(#fblur2)"
+                    strokeWidth={6} strokeLinecap="round" filter={`url(#fblur2-${uid})`}
                     strokeDasharray={`8 ${PL}`}
                     strokeDashoffset={dir === 1 ? -(Math.max(0, headP - 8)) : -(PL - headP)}
                     opacity={0.95} />

--- a/demos/ui-entrance/neon-frame-orbit-drop/NeonFrameForerunOrbit.tsx
+++ b/demos/ui-entrance/neon-frame-orbit-drop/NeonFrameForerunOrbit.tsx
@@ -4,7 +4,7 @@
 // （同帧起落、同帧贴合，同形软影同步收敛）。判例：整体登场镜=同时贴合，
 // 错峰是巡礼镜的语法。其余全部保留：同款霓虹渐变框+灰面板+背景霓虹管
 // 框群；镜头视角 rotateY 从左侧(+38°) 连续弧线旋到右侧(-26°)。
-import React from 'react';
+import React, { useId } from 'react';
 import { AbsoluteFill, useCurrentFrame, interpolate, Easing } from 'remotion';
 
 const easeFall = Easing.bezier(0.5, 0.05, 0.6, 1); // 加速下落、末端软着陆
@@ -149,6 +149,8 @@ const BG_FRAMES: BgFrame[] = Array.from({ length: 18 }).map(() => ({
 
 export const NeonFrameForerunOrbit: React.FC = () => {
   const frame = useCurrentFrame();
+  // 滤镜/渐变 ID 按实例生成，多实例同场不串引（useId 的 «:» 在 url() 里非法，需清洗）
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   // 开场快速描框（同款左缘中点两头奔画，14 帧成型——样式与 v3 一致）
   const trace = interpolate(frame, [0, 14], [0, 1], {
     extrapolateLeft: 'clamp', extrapolateRight: 'clamp',
@@ -191,7 +193,7 @@ export const NeonFrameForerunOrbit: React.FC = () => {
       {/* 背景霓虹管框群（同款） */}
       <svg width={1920} height={1080} style={{ position: 'absolute' }}>
         <defs>
-          <filter id="obgblur" x="-60%" y="-60%" width="220%" height="220%">
+          <filter id={`obgblur-${uid}`} x="-60%" y="-60%" width="220%" height="220%">
             <feGaussianBlur stdDeviation={7} />
           </filter>
         </defs>
@@ -201,7 +203,7 @@ export const NeonFrameForerunOrbit: React.FC = () => {
           return (
             <g key={i} transform={`translate(${b.x} ${b.y}) skewY(${b.skew * 0.4}) skewX(${b.skew})`}>
               <rect width={b.w} height={b.h} rx={4} fill="none"
-                stroke={b.hue} strokeWidth={7} filter="url(#obgblur)" opacity={op * 0.8} />
+                stroke={b.hue} strokeWidth={7} filter={`url(#obgblur-${uid})`} opacity={op * 0.8} />
               <rect width={b.w} height={b.h} rx={4} fill="none"
                 stroke={b.hue} strokeWidth={2} opacity={op} />
             </g>
@@ -231,34 +233,34 @@ export const NeonFrameForerunOrbit: React.FC = () => {
           <svg width={PW + 80} height={PH + 80} viewBox={`-40 -40 ${PW + 80} ${PH + 80}`}
             style={{ position: 'absolute', left: -40, top: -40 }}>
             <defs>
-              <linearGradient id="omainfg" gradientUnits="userSpaceOnUse" x1={0} y1={0} x2={PW} y2={PH}>
+              <linearGradient id={`omainfg-${uid}`} gradientUnits="userSpaceOnUse" x1={0} y1={0} x2={PW} y2={PH}>
                 <stop offset="0%" stopColor="#c07af5" />
                 <stop offset="38%" stopColor="#e58bd8" />
                 <stop offset="72%" stopColor="#f0b06a" />
                 <stop offset="100%" stopColor="#e8925c" />
               </linearGradient>
-              <filter id="ofblur" x="-40%" y="-40%" width="180%" height="180%">
+              <filter id={`ofblur-${uid}`} x="-40%" y="-40%" width="180%" height="180%">
                 <feGaussianBlur stdDeviation={10} />
               </filter>
-              <filter id="ofblur2" x="-40%" y="-40%" width="180%" height="180%">
+              <filter id={`ofblur2-${uid}`} x="-40%" y="-40%" width="180%" height="180%">
                 <feGaussianBlur stdDeviation={3} />
               </filter>
             </defs>
             {[1, -1].map((dir) => (
               <g key={dir}>
-                <path d={FRAME_D} pathLength={PL} fill="none" stroke="url(#omainfg)"
-                  strokeWidth={14} strokeLinecap="butt" filter="url(#ofblur)"
+                <path d={FRAME_D} pathLength={PL} fill="none" stroke={`url(#omainfg-${uid})`}
+                  strokeWidth={14} strokeLinecap="butt" filter={`url(#ofblur-${uid})`}
                   strokeDasharray={`${headP} ${PL}`}
                   strokeDashoffset={dir === 1 ? 0 : -(PL - headP)}
                   opacity={0.6 * rimGlow} />
-                <path d={FRAME_D} pathLength={PL} fill="none" stroke="url(#omainfg)"
+                <path d={FRAME_D} pathLength={PL} fill="none" stroke={`url(#omainfg-${uid})`}
                   strokeWidth={3.5} strokeLinecap="butt"
                   strokeDasharray={`${headP} ${PL}`}
                   strokeDashoffset={dir === 1 ? 0 : -(PL - headP)}
                   opacity={0.95 * frameLine} />
                 {trace < 1 && (
                   <path d={FRAME_D} pathLength={PL} fill="none" stroke="#ffffff"
-                    strokeWidth={6} strokeLinecap="round" filter="url(#ofblur2)"
+                    strokeWidth={6} strokeLinecap="round" filter={`url(#ofblur2-${uid})`}
                     strokeDasharray={`8 ${PL}`}
                     strokeDashoffset={dir === 1 ? -(Math.max(0, headP - 8)) : -(PL - headP)}
                     opacity={0.95} />


### PR DESCRIPTION
外部评审指出新卡 GrainDissolve 的 SVG 固定 ID 有多实例串引风险（已在 #27 分支修复）；本 PR 清理老 104 卡 demo 里同模式的**存量 13 个文件**（首轮 12 个 + 审查补漏 1 个：MagicianCardFlourish 的 const 字符串形式 `SPIKE_ID` 逃过了 `id="` 与 `url(#` 两条 grep，二轮多形式全库扫描后补齐）。

## 问题

固定字符串 id（`filter`/`mask`/`clipPath`/`gradient`）在同一 Composition 挂两个实例时（错峰双实例、对比排版等场景）会互相串引：SVG 的 `url(#id)` 按文档全局解析，后挂载实例的 defs 覆盖前者，滤镜/渐变参数跟错实例的动画进度。

## 修法

全部改为 `useId()` 派生（清洗掉 CSS `url()` 里非法的 `:`，保留原 ID 作可读前缀）。两个飞线组件（FlylineArc / OrbFlylineRelay）的 ID 在父组件生成后经 prop 传给子组件，避免子组件多次调 useId。

| 文件 | 原固定 ID |
|---|---|
| SteepTiltGlide | cu1 / cu2 |
| FlylineArc | headHalo |
| OrbFlylineRelay | orbHeadHalo |
| LineBoil | boil |
| FreezeAnnotateReal | rough |
| CardFlockTumble | smokeA/B/C / ringGrad / strokeGrad |
| InkBleedReveal | inkBleed / inkMask |
| LetterformZoom | lfz-cut |
| MarkerUnderlineTitle | reveal |
| IntegrationHubMap | pipeGlow（rainbow-N 加实例前缀） |
| NeonFrameForerun | bgblur / mainfg / fblur / fblur2 |
| NeonFrameForerunOrbit | obgblur / omainfg / ofblur / ofblur2 |
| MagicianCardFlourish（补漏） | mcf-needle（const 变体） |

## 验证

- 12 组件 tsc strict（`--noEmit --strict`）通过
- **像素零回退**：改动前后各渲 still 比对（首轮 12 组件 × f15/45/90/135 共 48 张；补漏组件 × 6 帧含闪光活跃期 f3/f8/f13），全部**逐字节一致**——纯 ID 重命名，不触碰任何渲染路径
- 收尾复核：`demos/` 下固定 SVG ID 已清零（含 `id="`、`id={CONST}`、非插值 `url(#` 等全部形式）
- **双实例串引验证**（回应二轮评审"单实例一致不能证明多实例不串引"）：react-dom/server 把 13 个组件各自**同树挂两个实例**、跨 10 个代表帧（覆盖各组件的条件挂载窗口）渲染，断言全文档 SVG ID 零重复、全部 `url(#)`/mask/clip-path 引用可解析——**628 个 ID 定义全过**。阴性对照：同一断言跑 main 上的旧代码，LineBoil/InkBleedReveal/MagicianCardFlourish 全部被抓出重复 ID，证明测试有判别力

🤖 Generated with [Claude Code](https://claude.com/claude-code)

