### PR TITLE
fix: escape media.url in gallery data-src attributes

### DIFF
--- a/gallery/app.js
+++ b/gallery/app.js
@@ -149,13 +149,13 @@ function mediaMarkup(style, cardIndex) {
   if (style.media.type === 'gif') {
     return `
       <figure class="preview">
-        <img class="lazy-media" data-src="${style.media.url}" alt="${title}" loading="lazy">
+        <img class="lazy-media" data-src="${escapeHtml(style.media.url)}" alt="${title}" loading="lazy">
       </figure>`;
   }
 
   return `
     <figure class="preview">
-      <video class="lazy-media" data-src="${style.media.url}" muted loop playsinline preload="none"
+      <video class="lazy-media" data-src="${escapeHtml(style.media.url)}" muted loop playsinline preload="none"
         aria-label="${title}" data-key="${cardIndex}"></video>
       <button class="video-expand" type="button" aria-label="${escapeHtml(text('fullscreen'))} ${title}"
         data-expand-key="${cardIndex}" title="${escapeHtml(text('fullscreen'))}">


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `style.media.url` is interpolated unescaped into `data-src="..."` in both branches of `mediaMarkup()` (gallery/app.js), unlike the sibling `title`/`sourceUrl` values escaped elsewhere in the same file.

**Evidence**: A url of `"><script>alert(document.cookie)</script>` breaks out of the attribute and injects a live `<script>` tag into the rendered markup; reproduced locally against the unmodified function.

**Fix**: Wrap both interpolations with `escapeHtml(style.media.url)`, matching the existing pattern used for `sourceUrl` and `title`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unescaped-attribute-interpolation","fingerprint":"sha256:fe9bcce17b04db042b1843e383c797e9f8c507d99e5377e649272db1bbf664c5"},{"rule_id":"SEC-unescaped-attribute-interpolation","fingerprint":"sha256:feb1039c429e3ace708ddb25e1cb7d9238d2c588b33843a9785be78a245d7a57"}]}
nlpm-metadata-end -->