### PR TITLE
fix: exact-pin devDependency versions in template/package.json

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -14,7 +14,7 @@
     "remotion": "4.0.484"
   },
   "devDependencies": {
-    "@types/react": "^19.2.17",
-    "typescript": "^6.0.3"
+    "@types/react": "19.2.17",
+    "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `template/package.json` devDependencies (`@types/react`, `typescript`) use caret ranges while all runtime dependencies (`react`, `react-dom`, `remotion`, `@remotion/cli`) are exact-pinned.

**Evidence**: Inspected `template/package.json` lines 10-18 — `dependencies` block has no `^`/`~` on any entry, `devDependencies` block has `^` on both entries, an inconsistent pinning strategy within the same manifest.

**Fix**: Remove the caret from `@types/react` (`^19.2.17` → `19.2.17`) and `typescript` (`^6.0.3` → `6.0.3`) to match the exact-pin convention already used for runtime dependencies.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:df19dd4eff2d1c1ad1010c2ddee404ab7438f1ede59488b2a792f58ebe8485a7"},{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:da82d7cfbf59b7a19d1d2759314e782f64c7c0ab8eba84e0d04c867ef3cfc4ed"}]}
nlpm-metadata-end -->