### PR TITLE
docs: demos/README 列出用到 @remotion/motion-blur 的 8 个 demo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -16,7 +16,14 @@ demo 文件，不能只凭卡名假设目录结构。这里的组件是调校过
   （page-waterfall-wall 例外：它写的是 `textures/xxx.png`，放 `public/textures/`）。
 
 个别 demo 用到 `@remotion/motion-blur`（CameraMotionBlur），需
-`npm i @remotion/motion-blur`。
+`npm i @remotion/motion-blur`。名单（8 个文件 / 6 张卡）：
+
+- `camera/crash-zoom-punch/CrashZoomReal.tsx`、`CrashImpactReal.tsx`
+- `camera/space-camera-moves/DroneDiveLanding.tsx`
+- `opening/magician-card-flourish/MagicianCardFlourish.tsx`
+- `rhythm/speed-ramp-freeze/SpeedRampReal.tsx`
+- `transition/shot-transitions/WhipPanReal.tsx`、`WhipBrakeReal.tsx`
+- `transition/transition-hidden-cut/InvisibleCut.tsx`
 
 ## Motion 系 demo（2026-08 并入的 48 张卡）
 


### PR DESCRIPTION
#28 在 SKILL.md 写了"名单见 \`demos/README.md\`"，但 README 此前只写要装 \`@remotion/motion-blur\`、没有名单。按当前 \`demos/**/*.tsx\` 的 import 实测补齐：8 个文件、对应 6 张卡（crash-zoom-punch、space-camera-moves、magician-card-flourish、speed-ramp-freeze、shot-transitions、transition-hidden-cut）。

纯文档，一个文件 +8/−1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)