### PR TITLE
feat(assets/lib): ClipCard — wrap external video clips as card heroes for shot recipes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -182,7 +182,7 @@ SFX；只有完整分镜确认后才进入最终素材采集。用户从 Gallery
 ## 资产使用方式
 
 - `assets/lib/` 组件 **copy 进新项目**后自由修改（不 import 本库）。
-  清单：PageCam（2.5D 页面相机——一切"真实页面"镜头的地基）、DigitRoll、
+  清单：PageCam（2.5D 页面相机——一切"真实页面"镜头的地基）、ClipCard（把外部视频素材 mp4 包成可被镜头卡运镜骨架驱动的"卡片主角"，含 OffthreadVideo 交叉淡化循环——素材短于镜头时无缝续播）、DigitRoll、
   FlashCut、Caption、FlatPanel、VerticalTicker（3D 无限滚动墙）、
   helpers(rand/shake/camera/motion)。FlatPanel 与 helpers/camera 需要
   `three` + `@react-three/fiber` + `@remotion/three` 依赖，其余仅需 remotion。

--- a/assets/lib/ClipCard.tsx
+++ b/assets/lib/ClipCard.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { OffthreadVideo, Sequence, interpolate, staticFile, useCurrentFrame, useVideoConfig } from 'remotion';
+
+// ClipCard — wraps an external video clip (mp4) into a "card hero" that shot
+// recipes designed for DOM/SVG subjects (spotlight-hero-card,
+// magician-card-flourish, neon-frame-orbit-drop, quad-split…) can drive
+// directly. Fills the library gap where every card assumes generated DOM
+// content or page screenshots, never real footage.
+//
+// Battle-tested in a delivered 39s promo (spotlight push-in at zoom 1.7 on a
+// 512×512 clip; 3-up quad-split with 32px captions after a Q11 readability
+// review finding — small cards need captionSize raised to keep ≥32px).
+//
+// Crossfade loop: OffthreadVideo (as of 4.0.410) has no `loop` prop and
+// freezes past media end. Set `loopDurationInFrames` to the clip's length in
+// composition frames and each next pass fades in `loopCrossfadeInFrames`
+// early over the previous tail — reads as a seamless dissolve, not a jump cut.
+// Layer count derives from the enclosing Sequence duration automatically.
+
+const ACCENT = '#4da3ff'; // swap for your brand accent
+
+const LoopLayer: React.FC<{
+  src: string; size: number; muted: boolean; startFrom: number; fadeIn: number;
+}> = ({ src, size, muted, startFrom, fadeIn }) => {
+  const frame = useCurrentFrame();
+  const opacity = fadeIn > 0
+    ? interpolate(frame, [0, fadeIn], [0, 1], { extrapolateRight: 'clamp' })
+    : 1;
+  return (
+    <OffthreadVideo
+      src={staticFile(src)} muted={muted} startFrom={startFrom}
+      style={{ position: 'absolute', inset: 0, width: size, height: size, objectFit: 'cover', opacity }}
+    />
+  );
+};
+
+export const ClipCard: React.FC<{
+  src: string;              // path under public/
+  caption?: string;         // monospace caption bar under the clip
+  size?: number;            // card edge (square clips)
+  radius?: number;
+  muted?: boolean;
+  captionSize?: number;     // default 17 — raise on small/far cards to keep ≥32px on-screen text
+  startFrom?: number;
+  style?: React.CSSProperties;
+  loopDurationInFrames?: number;   // clip length in comp frames → enables crossfade loop
+  loopCrossfadeInFrames?: number;  // default 8
+}> = ({
+  src, caption, size = 560, radius = 20, muted = true, startFrom = 0, style,
+  captionSize = 17, loopDurationInFrames, loopCrossfadeInFrames = 8,
+}) => {
+  const { durationInFrames } = useVideoConfig();
+  const capH = caption ? Math.round(captionSize * 2.6) : 0;
+
+  let video: React.ReactNode;
+  if (loopDurationInFrames && loopDurationInFrames > loopCrossfadeInFrames) {
+    const step = loopDurationInFrames - loopCrossfadeInFrames;
+    const n = Math.max(1, Math.ceil(durationInFrames / step));
+    video = (
+      <div style={{ position: 'relative', width: size, height: size }}>
+        {Array.from({ length: n }, (_, i) => (
+          <Sequence key={i} from={i * step} durationInFrames={loopDurationInFrames} layout="none">
+            <LoopLayer
+              src={src} size={size} muted={muted} startFrom={startFrom}
+              fadeIn={i === 0 ? 0 : loopCrossfadeInFrames}
+            />
+          </Sequence>
+        ))}
+      </div>
+    );
+  } else {
+    video = (
+      <OffthreadVideo
+        src={staticFile(src)} muted={muted} startFrom={startFrom}
+        style={{ width: size, height: size, objectFit: 'cover', display: 'block' }}
+      />
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: size, height: size + capH, borderRadius: radius,
+        background: '#111116', border: '1px solid rgba(255,255,255,0.10)',
+        boxShadow: '0 24px 80px rgba(0,0,0,0.55)', overflow: 'hidden', ...style,
+      }}
+    >
+      {video}
+      {caption ? (
+        <div style={{
+          height: capH, display: 'flex', alignItems: 'center', padding: '0 18px',
+          fontFamily: 'ui-monospace, Menlo, monospace', fontSize: captionSize,
+          color: 'rgba(255,255,255,0.72)', letterSpacing: 0.5,
+          borderTop: '1px solid rgba(255,255,255,0.10)',
+        }}>
+          <span style={{ color: ACCENT, marginRight: 10 }}>▸</span>{caption}
+        </div>
+      ) : null}
+    </div>
+  );
+};


### PR DESCRIPTION
## Why

All 152 shot cards assume DOM/SVG-generated subjects or page screenshots — none support real video footage (mp4) as the card subject. When a promo needs to showcase *generated or recorded clips* (AI video output, screen recordings, product footage), there's no container that lets the existing motion grammars drive them.

## What

`ClipCard` wraps an `<OffthreadVideo>` into a rounded card with an optional monospace caption bar, so cards like `spotlight-hero-card`, `magician-card-flourish`, `neon-frame-orbit-drop`, and `quad-split-parallel-scenes` can treat footage exactly like the rectangular card element their demos were tuned on.

Includes a **crossfade loop**: `OffthreadVideo` (4.0.410) has no `loop` prop and freezes past media end; `loopDurationInFrames` enables seamless dissolve-looping when the clip is shorter than the shot (layer count auto-derived from the enclosing Sequence).

## Battle-tested

Used in a delivered 39s promo (9 shots, independent final review passed):

- `spotlight-hero-card` arc on a 512×512 clip at zoom 1.7 (camera rotY/rotX/persp at demo values, zoom re-derived for square media)
- 3-up `quad-split` with re-staggered beat table; crossfade loop covering a 70f clip in an 87f shot
- Review finding worth inheriting: default 17px caption fails the 32px on-screen text floor on small cards — hence the `captionSize` prop and the comment pointing at Q11

## Not included

No gallery card/preview (this is a container component, not a motion grammar; it lives in `assets/lib/` alongside PageCam/DigitRoll). Happy to add a recipe card + demo if you'd prefer it documented that way.

---

中文摘要:152 張卡都假設 DOM/SVG 素材,這個組件補上「真實影片素材」形態,讓既有運鏡卡直接驅動 mp4;含交叉淡化循環解 OffthreadVideo 無 loop 的問題。已在一支獨立終檢通過的成片中實戰(spotlight 聚光推進/三格並置)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbDjz7SLdtDiC9qx1yYv3u
