### PR TITLE
docs: 测试体系与 ClipCard 用法文档化

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -211,6 +211,13 @@ SFX；只有完整分镜确认后才进入最终素材采集。用户从 Gallery
   `npm i @remotion/motion-blur`，名单见 `demos/README.md`。
 - `template/` 完整可渲染工程：`npm install && npx remotion render
   src/index.ts AiflPromo out/promo.mp4`。
+- **测试（仓库内自动验证，新增 demo/组件后跑）**：
+  - 纯函数单测：`npm test`（仓库根 vitest，覆盖 `assets/lib/helpers` 的
+    mulberry32 / velocityAt / lagged / dampedSettle / handheld，确定性断言）。
+  - demo 渲染冒烟：`python3 assets/scripts/smoke-render-demos.py` 渲染每个
+    带时长导出 demo 的首帧断言不崩（需 `cd template && npm ci` +
+    motion-blur，详见 `demos/README.md` 测试与验证一节）。
+  - CI（`pr-checks.yml`）已自动跑：tsc 严格编译全部 demo + vitest + 冒烟渲染。
 - `jianying-export/` 剪映工程导出模块：`mac_draft.py`（Mac 剪映 11.2
   实测通过）、`windows_draft.py`（按上游支持路径实现，未真机验证）、
   `smoke_test.py`（新环境先跑的最小冒烟测试）。流程、时间线提取与建轨

--- a/demos/README.md
+++ b/demos/README.md
@@ -52,4 +52,62 @@ pill-chip-slot-cycle-handled）：挂载时用 useLayoutEffect 实测一次文�
 （之后恒定，单次渲染内仍逐帧确定），因此其布局随渲染环境的字体而变——
 跨平台若字体回退不同，宽度会整体漂移；组件内已备兜底估算值，介意的话
 可把实测值写死。每个组件都经过与原样片 mp4 的全帧 SSIM 比对验收
-（mean≥0.97 / min≥0.93 或有注释说明的编码噪声豁免）。
+ （mean≥0.97 / min≥0.93 或有注释说明的编码噪声豁免）。
+
+## 真实视频素材（ClipCard，assets/lib/ClipCard.tsx）
+
+库内 152 张镜头卡原本都假设主体是 DOM/SVG 生成物或页面截图，没有一张能
+直接承载真实 mp4 素材。`assets/lib/ClipCard` 补上这个形态：把一段视频包进
+圆角"卡片"，让为矩形卡元素调校过的运镜骨架（spotlight-hero-card /
+magician-card-flourish / neon-frame-orbit-drop / quad-split-parallel-scenes）
+原样驱动真实 footage。copy `assets/lib/ClipCard.tsx` 进项目即可用。
+
+```tsx
+import { ClipCard } from './assets/lib/ClipCard';
+
+// 素材放 public/clips/demo.mp4；素材短于镜头时传 loopDurationInFrames 开启
+// 交叉淡化循环（OffthreadVideo 无 loop prop，播完会冻结）
+<ClipCard src="clips/demo.mp4" size={560} caption="AI generated"
+  loopDurationInFrames={60} durationInFrames={120} />
+```
+
+| 参数 | 默认 | 说明 |
+|------|------|------|
+| `src` | 必填 | public/ 下视频路径（staticFile 解析） |
+| `caption` / `captionSize` | 无 / 17 | 卡片下方 mono 副行；小卡片/远机位 captionSize 提到 ≥32px（Q11） |
+| `size` / `radius` | 560 / 20 | 卡片边长（方形素材）/ 圆角 |
+| `muted` | true | `false` 时循环交叉淡化音频互补，不叠双全量音轨 |
+| `startFrom` | 0 | 从视频第几帧开始播（修剪） |
+| `loopDurationInFrames` | 无 | 视频可播放长度（合成帧）→ 开启循环 |
+| `loopCrossfadeInFrames` | 8 | 循环层重叠淡化帧数 |
+| `durationInFrames` | Composition 时长 | 包围 shot 时长——**务必传**，否则短 shot 嵌长工程会生成不可见层 |
+
+已知坑：
+- `durationInFrames` 不传时层数按 Composition 总时长算（短 shot 长工程问题）。
+- `startFrom` ≥ 可播放长度、或 step < crossfade 时自动回退单层播放（不循环）。
+- 循环素材建议 30fps、方形（运镜骨架按方形卡片标定）。
+
+参考 demo：`demos/ui-entrance/clipcard-looping/ClipCardLooping.tsx`
+（回归三场景：muted=false 循环、startFrom>0+循环、短 Sequence 长 Composition）。
+
+## 测试与验证
+
+1. **类型编译**（`pr-checks.yml` verify job）：`find demos -name '*.tsx'`
+   全部走 `tsc --noEmit --strict`。新增 demo 必须能通过严格编译。
+2. **渲染冒烟**（`assets/scripts/smoke-render-demos.py`）：扫描所有带时长
+   导出（`_DURATION` / `_DUR`）的 demo，自动生成 `template/src/smoke-root.tsx`
+   注册全部，逐个 `remotion still` 渲染首帧，断言输出非空、进程不崩——
+   堵住"能编译不能运行"的 demo（如 composition id 非法、运行时 import
+   缺失、纹理缺失）。本地跑全量：
+
+   ```bash
+   # 需要 template 依赖 + motion-blur（CI 里临时装）
+   cd template && npm ci && npm i --no-save "@remotion/motion-blur@$(node -p "require('./package.json').dependencies.remotion")"
+   cd .. && python3 assets/scripts/smoke-render-demos.py        # 全量
+   python3 assets/scripts/smoke-render-demos.py --subset BlurSlide,Scramble  # 子集
+   python3 assets/scripts/smoke-render-demos.py --list          # 列出可渲染 demo
+   ```
+
+   `--subset` 指向不存在/未找到的 demo 时脚本退出码为 1（明确报错）。
+   需要真实 mp4 素材的 demo（如 ClipCardLooping 用 `public/clips/`）会被跳过
+   并在输出里报告，不阻塞全量。


### PR DESCRIPTION
## 背景

#42(vitest) 和 #43(demo 冒烟)合并后,**测试体系在 SKILL.md / demos/README 里完全没被提及**——用户和代理不知道有这些测试、怎么跑、何时跑。ClipCard(#39)合并后也只有 SKILL.md 一句话,没有完整用法文档。

## 改动

**demos/README.md**
- 新增「真实视频素材(ClipCard)」节:完整参数表(src/caption/size/muted/startFrom/loopDurationInFrames/loopCrossfadeInFrames/durationInFrames)、交叉淡化循环原理、已知坑(必须传 durationInFrames、startFrom 超长自动回退、建议 30fps 方形素材)、参考 demo 定位
- 新增「测试与验证」节:类型编译 + 渲染冒烟两层验证,本地全量/子集/列出的跑法(含 motion-blur 临时装),--subset 指向不存在 demo 时退出码 1

**SKILL.md**
- 资产清单新增「测试(仓库内自动验证)」条目:纯函数单测(npm test)、demo 渲染冒烟(smoke-render-demos.py)、CI 已自动跑三层

## 设计决策

ClipCard 是**容器组件**(把真实 mp4 包成卡片主体),不是动效镜头——按你的建议不入 152 卡体系,只做文档化(避免污染"152 张镜头卡"的语义)。gallery 无 drift。

## 验证

- 仅文档改动,gallery sync 后无 drift
- demos/README 结构完整(3 个 ## 节)