### PR TITLE
feat(gallery): Showcase 用户投稿页 + 审核发布流水线

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase.yml
+++ b/.github/ISSUE_TEMPLATE/showcase.yml
@@ -1,0 +1,70 @@
+# Showcase 投稿表单。字段的 label 是发布流水线的解析锚点
+# （.github/scripts/showcase-publish.py 按 "### <label>" 切段），
+# 改 label 必须同步改脚本里的 FIELD_* 常量。
+name: "🎬 Showcase 作品投稿 / Submit your video"
+description: 提交你用 video-shotcraft 做的成片，审核通过后自动发布到 Gallery 的 Showcase 页 / Submit a video made with video-shotcraft for the gallery Showcase page.
+title: "[Showcase] 你的作品名 / Your video title"
+labels: ["showcase"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢投稿！维护者审核通过后，作品会自动发布到
+        [Showcase 页](https://vincentwei1021.github.io/video-shotcraft/showcase.html)，
+        并展示你留下的社交账号，方便观众找到你。
+
+        **视频提供方式二选一**：≤10MB 的 mp4 直接拖进「视频文件」输入框；
+        更大的文件填「视频外部链接」（需要可直接下载的 URL）。
+  - type: input
+    id: video-title
+    attributes:
+      label: 作品名
+      description: 显示在 Showcase 卡片上的标题
+      placeholder: 例：Acme Dashboard 产品宣传片
+    validations:
+      required: true
+  - type: textarea
+    id: video-description
+    attributes:
+      label: 一句话介绍
+      description: 这支视频是给什么产品/项目做的，想突出什么
+    validations:
+      required: true
+  - type: input
+    id: shot-cards
+    attributes:
+      label: 用到的镜头卡（可选）
+      placeholder: 例：spotlight-hero-card, deck-deal-flyin
+  - type: textarea
+    id: video-file
+    attributes:
+      label: 视频文件（≤10MB 直接拖拽上传）
+      description: 把 mp4 拖进这里，GitHub 会自动生成附件链接；超过 10MB 请改填下面的外部链接
+  - type: input
+    id: video-url
+    attributes:
+      label: 视频外部链接（大文件用）
+      description: 可直接下载的视频 URL（对象存储/网盘直链等，打开即开始下载或直接是视频流）
+  - type: input
+    id: social-x
+    attributes:
+      label: X 账号（可选）
+      description: "@handle 或主页链接，会显示在你的作品卡片上"
+      placeholder: "@yourhandle 或 https://x.com/yourhandle"
+  - type: input
+    id: social-xiaohongshu
+    attributes:
+      label: 小红书（可选）
+      description: 主页链接或小红书号
+  - type: input
+    id: social-douyin
+    attributes:
+      label: 抖音（可选）
+      description: 主页链接或抖音号
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: 授权确认
+      options:
+        - label: 我拥有该视频的版权/发布权，同意在 video-shotcraft Showcase 页公开展示（可随时开 issue 要求下架）
+          required: true

--- a/.github/scripts/showcase-publish.py
+++ b/.github/scripts/showcase-publish.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Publish an approved showcase submission (run by showcase-publish.yml).
+
+流程：解析投稿 issue 的表单正文 → 下载视频（issue 附件或外部直链）→
+ffmpeg 规整成 h264 mp4 + 抽 poster → 转存到 showcase-media release →
+更新 release 上的 showcase.json → 触发 deploy-pages 重新部署 → 回帖并关闭
+issue。投稿媒体与 showcase.json 全程只存 release 资产，不进 git。
+
+字段解析锚点是 issue form 各字段的 label（GitHub 渲染为 "### <label>"），
+与 .github/ISSUE_TEMPLATE/showcase.yml 一一对应，两边必须同步改。
+
+环境变量（workflow 注入）：GH_TOKEN GH_REPO ISSUE_NUMBER ISSUE_BODY
+ISSUE_USER ISSUE_CREATED_AT RUN_ID
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+RELEASE_TAG = 'showcase-media'
+MAX_BYTES = 300 * 1024 * 1024  # 单支投稿上限 300MB
+SHOWCASE_URL = 'https://vincentwei1021.github.io/video-shotcraft/showcase.html'
+
+# 与 showcase.yml 各字段 label 一致
+FIELD_TITLE = '作品名'
+FIELD_DESC = '一句话介绍'
+FIELD_CARDS = '用到的镜头卡（可选）'
+FIELD_FILE = '视频文件（≤10MB 直接拖拽上传）'
+FIELD_URL = '视频外部链接（大文件用）'
+FIELD_X = 'X 账号（可选）'
+FIELD_XHS = '小红书（可选）'
+FIELD_DY = '抖音（可选）'
+
+ATTACHMENT_RE = re.compile(
+    r'https://github\.com/user-attachments/(?:assets/[\w-]+|files/\d+/\S+?)(?=[)\s"\']|$)'
+    r'|https://user-images\.githubusercontent\.com/\S+?(?=[)\s"\']|$)')
+URL_RE = re.compile(r'https?://\S+?(?=[)\s"\']|$)')
+
+
+def run(cmd, **kw):
+    print('+', ' '.join(str(c) for c in cmd), flush=True)
+    return subprocess.run(cmd, check=True, **kw)
+
+
+def parse_form(body):
+    """Issue form 正文按 '### <label>' 切段，值为段内文本。"""
+    sections = {}
+    current = None
+    for line in body.replace('\r\n', '\n').split('\n'):
+        if line.startswith('### '):
+            current = line[4:].strip()
+            sections[current] = []
+        elif current is not None:
+            sections[current].append(line)
+    fields = {}
+    for key, lines in sections.items():
+        value = '\n'.join(lines).strip()
+        fields[key] = '' if value == '_No response_' else value
+    return fields
+
+
+def pick_video_url(fields):
+    attachment = ATTACHMENT_RE.search(fields.get(FIELD_FILE, ''))
+    if attachment:
+        return attachment.group(0)
+    external = URL_RE.search(fields.get(FIELD_URL, ''))
+    if external:
+        return external.group(0)
+    sys.exit('投稿里既没有视频附件也没有外部链接，无法发布')
+
+
+def probe_codec(path):
+    result = subprocess.run(
+        ['ffprobe', '-v', 'error', '-select_streams', 'v:0',
+         '-show_entries', 'stream=codec_name', '-of', 'csv=p=0', str(path)],
+        capture_output=True, text=True)
+    if result.returncode != 0 or not result.stdout.strip():
+        sys.exit(f'ffprobe 认不出下载的文件，不是可用的视频：{result.stderr.strip()}')
+    return result.stdout.strip().splitlines()[0]
+
+
+def normalize_video(raw, out_mp4):
+    """h264 直接 remux（无损 + faststart），其余编码统一转码成 1080p 内 h264。"""
+    codec = probe_codec(raw)
+    if codec == 'h264':
+        remux = subprocess.run(
+            ['ffmpeg', '-y', '-i', str(raw), '-c', 'copy',
+             '-movflags', '+faststart', str(out_mp4)])
+        if remux.returncode == 0:
+            return
+    run(['ffmpeg', '-y', '-i', str(raw),
+         '-vf', "scale='min(1920,iw)':-2",
+         '-c:v', 'libx264', '-crf', '20', '-preset', 'veryfast',
+         '-pix_fmt', 'yuv420p', '-c:a', 'aac', '-b:a', '192k',
+         '-movflags', '+faststart', str(out_mp4)])
+
+
+def extract_poster(video, poster):
+    for seek in ('1', '0'):
+        result = subprocess.run(
+            ['ffmpeg', '-y', '-ss', seek, '-i', str(video), '-frames:v', '1',
+             '-vf', "scale='min(960,iw)':-2", str(poster)])
+        if result.returncode == 0 and poster.exists() and poster.stat().st_size > 0:
+            return
+    sys.exit('无法从视频抽取 poster 帧')
+
+
+def main():
+    env = os.environ
+    issue = int(env['ISSUE_NUMBER'])
+    fields = parse_form(env.get('ISSUE_BODY', ''))
+    title = fields.get(FIELD_TITLE, '').strip()
+    description = fields.get(FIELD_DESC, '').strip()
+    if not title or not description:
+        sys.exit('投稿缺少作品名或介绍，请补全后再加 approved 标签')
+
+    video_url = pick_video_url(fields)
+    work = Path(tempfile.mkdtemp(prefix='showcase-'))
+    raw = work / 'raw-video'
+    # -A 给个浏览器 UA：部分网盘直链对空 UA 返回 403
+    run(['curl', '-fSL', '--retry', '3', '--max-time', '600',
+         '--max-filesize', str(MAX_BYTES),
+         '-A', 'Mozilla/5.0 (video-shotcraft showcase bot)',
+         '-o', str(raw), video_url])
+    if raw.stat().st_size > MAX_BYTES:
+        sys.exit(f'视频超过 {MAX_BYTES // 1024 // 1024}MB 上限')
+
+    mp4 = work / f'showcase-{issue}.mp4'
+    poster = work / f'showcase-{issue}.jpg'
+    normalize_video(raw, mp4)
+    extract_poster(mp4, poster)
+
+    # release 首次投稿时自动创建
+    exists = subprocess.run(['gh', 'release', 'view', RELEASE_TAG],
+                            capture_output=True)
+    if exists.returncode != 0:
+        run(['gh', 'release', 'create', RELEASE_TAG,
+             '--title', 'Showcase media assets',
+             '--notes', 'User-submitted showcase videos + showcase.json '
+                        '(published by showcase-publish.yml, not tracked in git).'])
+
+    manifest_path = work / 'showcase.json'
+    fetched = subprocess.run(
+        ['gh', 'release', 'download', RELEASE_TAG, '--pattern', 'showcase.json',
+         '--dir', str(work), '--clobber'], capture_output=True)
+    if fetched.returncode == 0 and manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    else:
+        manifest = {'items': []}
+
+    now = datetime.now(timezone.utc).isoformat(timespec='seconds')
+    entry = {
+        'id': issue,
+        'title': title,
+        'description': description,
+        'cards': fields.get(FIELD_CARDS, '').strip(),
+        'author': {
+            'github': env.get('ISSUE_USER', ''),
+            'x': fields.get(FIELD_X, '').strip(),
+            'xiaohongshu': fields.get(FIELD_XHS, '').strip(),
+            'douyin': fields.get(FIELD_DY, '').strip(),
+        },
+        # ?v= 缓存穿透：重新发布同一 issue 时 Pages CDN 才会取新文件
+        'video': f'./showcase-media/showcase-{issue}.mp4?v={env.get("RUN_ID", "0")}',
+        'poster': f'./showcase-media/showcase-{issue}.jpg?v={env.get("RUN_ID", "0")}',
+        'submittedAt': env.get('ISSUE_CREATED_AT', ''),
+        'approvedAt': now,
+    }
+    manifest['items'] = ([entry]
+                         + [item for item in manifest['items'] if item.get('id') != issue])
+    manifest['updatedAt'] = now
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+
+    run(['gh', 'release', 'upload', RELEASE_TAG, str(mp4), str(poster),
+         str(manifest_path), '--clobber'])
+    # GITHUB_TOKEN 的 push 不触发 workflow，但显式 workflow_dispatch 可以
+    run(['gh', 'workflow', 'run', 'deploy-pages.yml'])
+    run(['gh', 'issue', 'comment', str(issue), '--body',
+         f'🎉 已发布！你的作品几分钟后会出现在 [Showcase 页]({SHOWCASE_URL})。\n\n'
+         f'需要修改或下架，随时在本 issue 留言或开新 issue。感谢投稿！'])
+    run(['gh', 'issue', 'close', str(issue), '--reason', 'completed'])
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -57,6 +57,24 @@ jobs:
             --pattern '*.mp4' \
             --clobber
 
+      - name: Download showcase submissions from the showcase-media release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p site/showcase-media
+          # 尚无投稿时 release 不存在：Showcase 页照常部署，列表为空
+          if gh release view showcase-media --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release download showcase-media \
+              --repo "$GITHUB_REPOSITORY" \
+              --dir site/showcase-media \
+              --clobber
+          fi
+          if [ -f site/showcase-media/showcase.json ]; then
+            mv site/showcase-media/showcase.json site/api/showcase.json
+          else
+            printf '{"items": []}\n' > site/api/showcase.json
+          fi
+
       - name: Check every library.json preview has its file
         run: |
           python3 - <<'EOF'

--- a/.github/workflows/showcase-publish.yml
+++ b/.github/workflows/showcase-publish.yml
@@ -1,0 +1,57 @@
+# Showcase 投稿发布：给带 `showcase` 标签的 issue 加 `showcase-approved`
+# 标签即触发。视频（issue 附件或外部直链）被规整成 h264 mp4 转存到
+# showcase-media release，release 上的 showcase.json 同步更新，然后
+# workflow_dispatch 触发 deploy-pages 重新部署——投稿媒体不进 git。
+#
+# 下架/改文案：`gh release download showcase-media --pattern showcase.json`
+# 改完 `gh release upload showcase-media showcase.json --clobber`，再手动
+# workflow_dispatch 触发 deploy-pages。
+name: Publish approved showcase submission
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write   # 上传 release 资产
+  issues: write     # 回帖 + 关闭投稿 issue
+  actions: write    # workflow_dispatch 触发 deploy-pages
+
+# 两个投稿同时过审时串行处理，避免 showcase.json 读改写互相覆盖
+concurrency:
+  group: showcase-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event.label.name == 'showcase-approved' &&
+      contains(github.event.issue.labels.*.name, 'showcase')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+
+      - name: Publish submission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # 经 env 传入，避免 issue 正文注入 shell
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
+          ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
+          RUN_ID: ${{ github.run_id }}
+        run: python3 .github/scripts/showcase-publish.py
+
+      - name: Report failure on the issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body \
+            "⚠️ 自动发布失败，维护者请查看 [run 日志](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})。常见原因：视频附件/外链无法下载、文件不是可识别的视频、超过 300MB 上限。"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ assets/images/
 # 样片 mp4 存 gallery-media release，不进 git（poster 小图仍在 git）；
 # 本地预览用 gallery/fetch-media.sh 拉取
 gallery/media/*.mp4
+# Showcase 用户投稿媒体与清单存 showcase-media release，不进 git
+gallery/showcase-media/
+gallery/api/showcase.json
 # 本地教程视频
 /video-shotcraft教程.mp4
 .DS_Store

--- a/SKILL.md
+++ b/SKILL.md
@@ -171,6 +171,14 @@ SFX；只有完整分镜确认后才进入最终素材采集。用户从 Gallery
 （可在剪映里改字幕内容/字号/颜色、分镜头变速/重排、调整或替换音频）；
 用户需要或直接点名导出时，读 `references/jianying-export.md` 执行。
 
+成片交付且用户满意后，**邀请一次 Showcase 投稿**：告诉用户可以把成片投稿到
+Gallery 的用户作品页 https://vincentwei1021.github.io/video-shotcraft/showcase.html ，
+入口是 https://github.com/Vincentwei1021/video-shotcraft/issues/new?template=showcase.yml 。
+说明两点吸引点：投稿可附上自己的 X / 小红书 / 抖音账号，作品上线后观众能
+顺着卡片直接找到作者；≤10MB 的 mp4 直接拖进表单即可，更大的文件填可直接
+下载的外部链接。维护者审核通过后自动发布。只邀请一次，用户拒绝或不回应
+就不再提。
+
 ## 何时读哪个文件
 
 | 时机 | 读 |

--- a/gallery/build-seo.py
+++ b/gallery/build-seo.py
@@ -100,6 +100,7 @@ newest = lib['stats']['newest'][:10]
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
     f'  <url><loc>{SITE}/</loc><lastmod>{newest}</lastmod></url>\n'
     f'  <url><loc>{SITE}/library.html</loc><lastmod>{newest}</lastmod></url>\n'
+    f'  <url><loc>{SITE}/showcase.html</loc><lastmod>{newest}</lastmod></url>\n'
     '</urlset>\n', encoding='utf-8')
 
 # 3. llms.txt

--- a/gallery/fetch-media.sh
+++ b/gallery/fetch-media.sh
@@ -10,3 +10,20 @@ gh release download gallery-media \
   --pattern '*.mp4' \
   --clobber
 echo "done: $(ls media/*.mp4 | wc -l | tr -d ' ') clips in gallery/media/"
+
+# Showcase 用户投稿（存 showcase-media release，同样不进 git）。
+# release 还不存在（尚无投稿）时静默跳过，showcase 页显示空列表。
+if gh release view showcase-media --repo Vincentwei1021/video-shotcraft >/dev/null 2>&1; then
+  mkdir -p showcase-media
+  gh release download showcase-media \
+    --repo Vincentwei1021/video-shotcraft \
+    --dir showcase-media \
+    --clobber
+  if [ -f showcase-media/showcase.json ]; then
+    mv showcase-media/showcase.json api/showcase.json
+  fi
+  echo "done: $(ls showcase-media/*.mp4 2>/dev/null | wc -l | tr -d ' ') showcase clips"
+else
+  printf '{"items": []}\n' > api/showcase.json
+  echo "no showcase-media release yet: wrote empty api/showcase.json"
+fi

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -152,6 +152,27 @@
       cursor: pointer;
     }
     .language-switch button.is-active { color: var(--text); font-weight: 700; background: rgba(240, 237, 229, 0.1); }
+    .topbar-nav {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.55rem;
+    }
+    .topbar-nav-link {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 0.38rem 0.95rem;
+      color: var(--muted);
+      background: rgba(14, 14, 12, 0.35);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      font-size: 0.8rem;
+      text-decoration: none;
+      white-space: nowrap;
+      transition: color 150ms ease, border-color 150ms ease;
+    }
+    .topbar-nav-link:hover { color: var(--text); border-color: rgba(211, 146, 60, 0.65); }
 
     /* ---- hero ---- */
     .hero {
@@ -383,9 +404,12 @@
       <img class="brand-mark" src="./logo-mark-reverse.svg" alt="" width="24" height="24" aria-hidden="true">
       <span>VIDEO SHOTCRAFT</span>
     </a>
-    <nav class="language-switch" id="languageSwitch" aria-label="Language">
-      <button type="button" data-language="zh" aria-pressed="false">中文</button>
-      <button type="button" data-language="en" aria-pressed="true">EN</button>
+    <nav class="topbar-nav" aria-label="Site">
+      <a class="topbar-nav-link" href="./showcase.html" data-l10n="navShowcase">Showcase</a>
+      <span class="language-switch" id="languageSwitch" role="group" aria-label="Language">
+        <button type="button" data-language="zh" aria-pressed="false">中文</button>
+        <button type="button" data-language="en" aria-pressed="true">EN</button>
+      </span>
     </nav>
   </header>
 
@@ -427,6 +451,7 @@
         statSamples: 'motion previews',
         statTemplate: 'ready template',
         footer: 'Apache-2.0 · Built with Remotion · ',
+        navShowcase: 'Showcase',
       },
       zh: {
         kicker: '一个 Claude Code / Codex 的 agent skill',
@@ -439,6 +464,7 @@
         statSamples: '动态样片',
         statTemplate: '现成模板',
         footer: 'Apache-2.0 · 基于 Remotion 构建 · ',
+        navShowcase: '用户作品',
       },
     };
 

--- a/gallery/library.html
+++ b/gallery/library.html
@@ -62,6 +62,7 @@
       <span>VIDEO SHOTCRAFT</span>
     </a>
     <div class="topbar-actions">
+      <a class="topbar-link" href="./showcase.html" data-i18n="navShowcase">Showcase</a>
       <div class="theme-switch" id="themeSwitch" role="group" aria-label="Page theme">
         <button type="button" data-theme="system" aria-pressed="true">Auto</button>
         <button type="button" data-theme="light" aria-pressed="false">Light</button>

--- a/gallery/showcase.html
+++ b/gallery/showcase.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="description" content="Community showcase — product videos made with video-shotcraft, an AI agent skill for Claude Code &amp; Codex that crafts cinematic promo videos with Remotion.">
+  <link rel="canonical" href="https://vincentwei1021.github.io/video-shotcraft/showcase.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="video-shotcraft">
+  <meta property="og:title" content="Showcase — videos made with video-shotcraft">
+  <meta property="og:description" content="Product videos the community made with the video-shotcraft agent skill. Submit yours and get featured with your social handles.">
+  <meta property="og:url" content="https://vincentwei1021.github.io/video-shotcraft/showcase.html">
+  <meta property="og:image" content="https://vincentwei1021.github.io/video-shotcraft/og-image.jpg?v=20260726b">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" href="./logo-mark.svg" type="image/svg+xml">
+  <title>Showcase — videos made with video-shotcraft</title>
+  <script>
+    try {
+      const choice = localStorage.getItem('video-shot-gallery-theme') || 'system';
+      const theme = choice === 'system'
+        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        : choice;
+      document.documentElement.dataset.theme = theme;
+      document.documentElement.dataset.themeChoice = choice;
+      document.documentElement.style.colorScheme = theme;
+    } catch {}
+  </script>
+  <link rel="stylesheet" href="./styles.css">
+  <script src="./showcase.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#showcase" data-i18n="skip">Skip to showcase</a>
+  <header class="topbar">
+    <a class="brand" href="./" aria-label="video-shotcraft home" data-i18n-aria-label="brandHome">
+      <img class="brand-mark brand-mark-light" src="./logo-mark.svg" alt="" width="24" height="24" aria-hidden="true">
+      <img class="brand-mark brand-mark-dark" src="./logo-mark-reverse.svg" alt="" width="24" height="24" aria-hidden="true">
+      <span>VIDEO SHOTCRAFT</span>
+    </a>
+    <div class="topbar-actions">
+      <a class="topbar-link" href="./library.html" data-i18n="navLibrary">Shot library</a>
+      <div class="theme-switch" id="themeSwitch" role="group" aria-label="Page theme">
+        <button type="button" data-theme="system" aria-pressed="true">Auto</button>
+        <button type="button" data-theme="light" aria-pressed="false">Light</button>
+        <button type="button" data-theme="dark" aria-pressed="false">Dark</button>
+      </div>
+      <div class="language-switch" id="languageSwitch" role="group" aria-label="Language">
+        <button type="button" data-language="zh" aria-pressed="false">中文</button>
+        <button type="button" data-language="en" aria-pressed="true">EN</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="showcase-layout">
+    <section class="intro showcase-intro" aria-labelledby="pageTitle">
+      <div class="intro-copy">
+        <h1 id="pageTitle" data-i18n="title">Community Showcase</h1>
+        <p class="intro-description" data-i18n="intro">Product videos the community made with video-shotcraft. Every card links back to its author — submit yours and leave your handles so viewers can find you.</p>
+      </div>
+      <a class="showcase-submit" href="https://github.com/Vincentwei1021/video-shotcraft/issues/new?template=showcase.yml" target="_blank" rel="noreferrer" data-i18n="submitCta">Submit your video</a>
+    </section>
+
+    <section class="showcase-grid" id="showcase" aria-live="polite" aria-busy="true"></section>
+
+    <section class="empty-state" id="emptyState" hidden>
+      <p data-i18n="empty">No submissions yet — be the first one featured here.</p>
+      <a class="showcase-submit" href="https://github.com/Vincentwei1021/video-shotcraft/issues/new?template=showcase.yml" target="_blank" rel="noreferrer" data-i18n="submitCta">Submit your video</a>
+    </section>
+  </main>
+</body>
+</html>

--- a/gallery/showcase.js
+++ b/gallery/showcase.js
@@ -1,0 +1,278 @@
+// Showcase 页：渲染社区投稿（./api/showcase.json，由 showcase-publish.yml
+// 维护在 showcase-media release 上，部署时装配进站点）。自带 L10N，
+// 不依赖 translations.js / app.js（那两者与镜头库 DOM 强耦合）。
+const SHOWCASE_L10N = {
+  en: {
+    documentTitle: 'Showcase — videos made with video-shotcraft',
+    skip: 'Skip to showcase',
+    brandHome: 'video-shotcraft home',
+    navLibrary: 'Shot library',
+    title: 'Community Showcase',
+    intro: 'Product videos the community made with video-shotcraft. Every card links back to its author — submit yours and leave your handles so viewers can find you.',
+    submitCta: 'Submit your video',
+    empty: 'No submissions yet — be the first one featured here.',
+    loadFailed: 'Could not load the showcase list.',
+    retry: 'Retry',
+    cardsUsed: 'Shot cards',
+    by: 'by',
+    fullscreen: 'Fullscreen',
+  },
+  zh: {
+    documentTitle: 'Showcase 用户作品 | video-shotcraft',
+    skip: '跳到作品列表',
+    brandHome: '回到主页',
+    navLibrary: '镜头库',
+    title: '用户作品 Showcase',
+    intro: '社区用 video-shotcraft 做出的产品视频。每张卡片都带作者的社交账号——投稿你的成片，让观众找到你。',
+    submitCta: '投稿我的作品',
+    empty: '还没有投稿——来做第一个被展示的作品吧。',
+    loadFailed: '作品列表加载失败。',
+    retry: '重试',
+    cardsUsed: '用到的镜头卡',
+    by: '作者',
+    fullscreen: '全屏播放',
+  },
+};
+
+const state = {
+  items: null,
+  language: (() => {
+    try { return localStorage.getItem('video-shot-gallery-language') === 'zh' ? 'zh' : 'en'; } catch { return 'en'; }
+  })(),
+  theme: (() => {
+    try {
+      const value = localStorage.getItem('video-shot-gallery-theme');
+      return ['system', 'light', 'dark'].includes(value) ? value : 'system';
+    } catch { return 'system'; }
+  })(),
+};
+
+const elements = {
+  grid: document.querySelector('#showcase'),
+  emptyState: document.querySelector('#emptyState'),
+  languageSwitch: document.querySelector('#languageSwitch'),
+  themeSwitch: document.querySelector('#themeSwitch'),
+};
+
+const text = (key) => SHOWCASE_L10N[state.language][key] || SHOWCASE_L10N.en[key] || key;
+
+const escapeHtml = (value = '') => String(value).replace(/[&<>'"]/g, (character) => ({
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  "'": '&#039;',
+  '"': '&quot;',
+}[character]));
+
+function resolveTheme(choice = state.theme) {
+  if (choice !== 'system') return choice;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme() {
+  const resolved = resolveTheme();
+  document.documentElement.dataset.theme = resolved;
+  document.documentElement.dataset.themeChoice = state.theme;
+  document.documentElement.style.colorScheme = resolved;
+  elements.themeSwitch.querySelectorAll('[data-theme]').forEach((button) => {
+    const active = button.dataset.theme === state.theme;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-pressed', String(active));
+  });
+}
+
+function applyLanguage() {
+  document.documentElement.lang = state.language === 'zh' ? 'zh-CN' : 'en';
+  document.title = text('documentTitle');
+  document.querySelectorAll('[data-i18n]').forEach((node) => {
+    node.textContent = text(node.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-aria-label]').forEach((node) => {
+    node.setAttribute('aria-label', text(node.dataset.i18nAriaLabel));
+  });
+  elements.languageSwitch.querySelectorAll('[data-language]').forEach((button) => {
+    const active = button.dataset.language === state.language;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-pressed', String(active));
+  });
+  applyTheme();
+}
+
+// 平台图标沿用 library 侧栏 social-badge 的 SVG path
+const PLATFORM_ICONS = {
+  github: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>',
+  x: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z"/></svg>',
+  douyin: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z"/></svg>',
+  xiaohongshu: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22.405 9.879c.002.016.01.02.07.019h.725a.797.797 0 0 0 .78-.972.794.794 0 0 0-.884-.618.795.795 0 0 0-.692.794c0 .101-.002.666.001.777zm-11.509 4.808c-.203.001-1.353.004-1.685.003a2.528 2.528 0 0 1-.766-.126.025.025 0 0 0-.03.014L7.7 16.127a.025.025 0 0 0 .01.032c.111.06.336.124.495.124.66.01 1.32.002 1.981 0 .01 0 .02-.006.023-.015l.712-1.545a.025.025 0 0 0-.024-.036zM.477 9.91c-.071 0-.076.002-.076.01a.834.834 0 0 0-.01.08c-.027.397-.038.495-.234 3.06-.012.24-.034.389-.135.607-.026.057-.033.042.003.112.046.092.681 1.523.787 1.74.008.015.011.02.017.02.008 0 .033-.026.047-.044.147-.187.268-.391.371-.606.306-.635.44-1.325.486-1.706.014-.11.021-.22.03-.33l.204-2.616.022-.293c.003-.029 0-.033-.03-.034zm7.203 3.757a1.427 1.427 0 0 1-.135-.607c-.004-.084-.031-.39-.235-3.06a.443.443 0 0 0-.01-.082c-.004-.011-.052-.008-.076-.008h-1.48c-.03.001-.034.005-.03.034l.021.293c.076.982.153 1.964.233 2.946.05.4.186 1.085.487 1.706.103.215.223.419.37.606.015.018.037.051.048.049.02-.003.742-1.642.804-1.765.036-.07.03-.055.003-.112zm3.861-.913h-.872a.126.126 0 0 1-.116-.178l1.178-2.625a.025.025 0 0 0-.023-.035l-1.318-.003a.148.148 0 0 1-.135-.21l.876-1.954a.025.025 0 0 0-.023-.035h-1.56c-.01 0-.02.006-.024.015l-.926 2.068c-.085.169-.314.634-.399.938a.534.534 0 0 0-.02.191.46.46 0 0 0 .23.378.981.981 0 0 0 .46.119h.59c.041 0-.688 1.482-.834 1.972a.53.53 0 0 0-.023.172.465.465 0 0 0 .23.398c.15.092.342.12.475.12l1.66-.001c.01 0 .02-.006.023-.015l.575-1.28a.025.025 0 0 0-.024-.035zm-6.93-4.937H3.1a.032.032 0 0 0-.034.033c0 1.048-.01 2.795-.01 6.829 0 .288-.269.262-.28.262h-.74c-.04.001-.044.004-.04.047.001.037.465 1.064.555 1.263.01.02.03.033.051.033.157.003.767.009.938-.014.153-.02.3-.06.438-.132.3-.156.49-.419.595-.765.052-.172.075-.353.075-.533.002-2.33 0-4.66-.007-6.991a.032.032 0 0 0-.032-.032zm11.784 6.896c0-.014-.01-.021-.024-.022h-1.465c-.048-.001-.049-.002-.05-.049v-4.66c0-.072-.005-.07.07-.07h.863c.08 0 .075.004.075-.074V8.393c0-.082.006-.076-.08-.076h-3.5c-.064 0-.075-.006-.075.073v1.445c0 .083-.006.077.08.077h.854c.075 0 .07-.004.07.07v4.624c0 .095.008.084-.085.084-.37 0-1.11-.002-1.304 0-.048.001-.06.03-.06.03l-.697 1.519s-.014.025-.008.036c.006.01.013.008.058.008 1.748.003 3.495.002 5.243.002.03-.001.034-.006.035-.033v-1.539zm4.177-3.43c0 .013-.007.023-.02.024-.346.006-.692.004-1.037.004-.014-.002-.022-.01-.022-.024-.005-.434-.007-.869-.01-1.303 0-.072-.006-.071.07-.07l.733-.003c.041 0 .081.002.12.015.093.025.16.107.165.204.006.431.002 1.153.001 1.153zm2.67.244a1.953 1.953 0 0 0-.883-.222h-.18c-.04-.001-.04-.003-.042-.04V10.21c0-.132-.007-.263-.025-.394a1.823 1.823 0 0 0-.153-.53 1.533 1.533 0 0 0-.677-.71 2.167 2.167 0 0 0-1-.258c-.153-.003-.567 0-.72 0-.07 0-.068.004-.068-.065V7.76c0-.031-.01-.041-.046-.039H17.93s-.016 0-.023.007c-.006.006-.008.012-.008.023v.546c-.008.036-.057.015-.082.022h-.95c-.022.002-.028.008-.03.032v1.481c0 .09-.004.082.082.082h.913c.082 0 .072.128.072.128V11.19s.003.117-.06.117h-1.482c-.068 0-.06.082-.06.082v1.445s-.01.068.064.068h1.457c.082 0 .076-.006.076.079v3.225c0 .088-.007.081.082.081h1.43c.09 0 .082.007.082-.08v-3.27c0-.029.006-.035.033-.035l2.323-.003c.098 0 .191.02.28.061a.46.46 0 0 1 .274.407c.008.395.003.79.003 1.185 0 .259-.107.367-.33.367h-1.218c-.023.002-.029.008-.028.033.184.437.374.871.57 1.303a.045.045 0 0 0 .04.026c.17.005.34.002.51.003.15-.002.517.004.666-.01a2.03 2.03 0 0 0 .408-.075c.59-.18.975-.698.976-1.313v-1.981c0-.128-.01-.254-.034-.38 0 .078-.029-.641-.724-.998z"/></svg>',
+};
+
+// x/github 的裸 handle 能可靠拼出主页 URL；小红书号/抖音号拼不出，
+// 只有用户填的是链接才可点，否则渲染成纯文本徽章
+function platformHref(platform, value) {
+  const v = value.trim();
+  if (/^https?:\/\//i.test(v)) return v;
+  if (platform === 'x') return `https://x.com/${v.replace(/^@/, '')}`;
+  if (platform === 'github') return `https://github.com/${v.replace(/^@/, '')}`;
+  return '';
+}
+
+function platformLabel(platform, value) {
+  const v = value.trim();
+  if (platform === 'github') return `@${v.replace(/^@/, '')}`;
+  if (platform === 'x') {
+    if (/^https?:\/\//i.test(v)) {
+      const handle = v.replace(/\/+$/, '').split('/').pop().split('?')[0];
+      return handle ? `@${handle.replace(/^@/, '')}` : 'X';
+    }
+    return `@${v.replace(/^@/, '')}`;
+  }
+  const names = {xiaohongshu: '小红书', douyin: '抖音'};
+  return /^https?:\/\//i.test(v) ? names[platform] : `${names[platform]} ${v}`;
+}
+
+function authorChip(platform, value) {
+  if (!value || !value.trim()) return '';
+  const href = platformHref(platform, value);
+  const icon = PLATFORM_ICONS[platform] || '';
+  const label = escapeHtml(platformLabel(platform, value));
+  const inner = `${icon}<span>${label}</span>`;
+  if (!href) return `<span class="author-chip" data-platform="${platform}">${inner}</span>`;
+  return `<a class="author-chip" data-platform="${platform}" href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${inner}</a>`;
+}
+
+function itemMarkup(item, index) {
+  const author = item.author || {};
+  const chips = [
+    authorChip('github', author.github),
+    authorChip('x', author.x),
+    authorChip('xiaohongshu', author.xiaohongshu),
+    authorChip('douyin', author.douyin),
+  ].filter(Boolean).join('');
+  const posterAttr = item.poster ? ` poster="${escapeHtml(item.poster)}"` : '';
+  return `
+    <article class="shot-card showcase-card">
+      <div class="card-media">
+        <figure class="preview">
+          <video class="lazy-media" data-src="${escapeHtml(item.video)}"${posterAttr} muted loop playsinline preload="none"
+            aria-label="${escapeHtml(item.title)}" data-key="${index}"></video>
+          <button class="video-expand" type="button" aria-label="${escapeHtml(text('fullscreen'))} ${escapeHtml(item.title)}"
+            data-expand-key="${index}" title="${escapeHtml(text('fullscreen'))}">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 4H5a1 1 0 0 0-1 1v4M15 4h4a1 1 0 0 1 1 1v4M9 20H5a1 1 0 0 1-1-1v-4M15 20h4a1 1 0 0 0 1-1v-4"/></svg>
+          </button>
+        </figure>
+      </div>
+      <div class="card-body">
+        <div class="card-title">
+          <h3>${escapeHtml(item.title)}</h3>
+        </div>
+        <p class="summary">${escapeHtml(item.description)}</p>
+        ${item.cards ? `<p class="showcase-cards-used"><span>${escapeHtml(text('cardsUsed'))}</span> ${escapeHtml(item.cards)}</p>` : ''}
+        ${chips ? `<div class="showcase-author" aria-label="${escapeHtml(text('by'))}">${chips}</div>` : ''}
+      </div>
+    </article>`;
+}
+
+function render() {
+  if (!state.items) return;
+  elements.grid.innerHTML = state.items.map(itemMarkup).join('');
+  elements.grid.setAttribute('aria-busy', 'false');
+  elements.emptyState.hidden = state.items.length > 0;
+  observeMedia();
+}
+
+let mediaObserver;
+function observeMedia() {
+  mediaObserver?.disconnect();
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  mediaObserver = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      const media = entry.target;
+      if (entry.isIntersecting) {
+        if (!media.src && media.dataset.src) media.src = media.dataset.src;
+        if (!reduceMotion && entry.intersectionRatio > 0.55) media.play().catch(() => {});
+      } else {
+        media.pause();
+      }
+    });
+  }, {rootMargin: '320px 0px', threshold: [0, 0.55]});
+  document.querySelectorAll('.lazy-media').forEach((media) => mediaObserver.observe(media));
+}
+
+// 全屏逻辑与 app.js 同款：原生 Fullscreen API 优先，iOS 退化到原生播放器
+function openFullscreen(key) {
+  const video = document.querySelector(`video[data-key="${key}"]`);
+  if (!video) return;
+  if (!video.src && video.dataset.src) video.src = video.dataset.src;
+  const stage = video.closest('.preview');
+  if (stage?.requestFullscreen) {
+    stage.requestFullscreen().then(() => {
+      video.controls = true;
+      video.play().catch(() => {});
+    }).catch(() => {});
+    return;
+  }
+  if (video.webkitEnterFullscreen) {
+    video.play().catch(() => {});
+    video.webkitEnterFullscreen();
+    return;
+  }
+  stage?.scrollIntoView({block: 'center'});
+  video.play().catch(() => {});
+}
+
+document.addEventListener('fullscreenchange', () => {
+  document.querySelectorAll('.preview.is-fullscreen').forEach((el) => {
+    el.classList.remove('is-fullscreen');
+    const video = el.querySelector('video');
+    if (video) video.controls = false;
+  });
+  document.fullscreenElement?.classList.add('is-fullscreen');
+});
+
+elements.grid.addEventListener('click', (event) => {
+  const expand = event.target.closest('[data-expand-key]');
+  if (expand) openFullscreen(expand.dataset.expandKey);
+});
+
+elements.languageSwitch.addEventListener('click', (event) => {
+  const button = event.target.closest('[data-language]');
+  if (!button || button.dataset.language === state.language) return;
+  state.language = button.dataset.language;
+  try { localStorage.setItem('video-shot-gallery-language', state.language); } catch {}
+  applyLanguage();
+  render();
+});
+
+elements.themeSwitch.addEventListener('click', (event) => {
+  const button = event.target.closest('[data-theme]');
+  if (!button || button.dataset.theme === state.theme) return;
+  state.theme = button.dataset.theme;
+  try { localStorage.setItem('video-shot-gallery-theme', state.theme); } catch {}
+  applyTheme();
+});
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  if (state.theme === 'system') applyTheme();
+});
+
+async function loadShowcase() {
+  try {
+    const response = await fetch('./api/showcase.json', {cache: 'no-store'});
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const manifest = await response.json();
+    state.items = Array.isArray(manifest.items) ? manifest.items : [];
+    render();
+  } catch (error) {
+    console.error(error);
+    elements.grid.setAttribute('aria-busy', 'false');
+    elements.grid.innerHTML = `
+      <div class="load-error">
+        <p>${escapeHtml(text('loadFailed'))}</p>
+        <button type="button" id="retryLoad">${escapeHtml(text('retry'))}</button>
+      </div>`;
+    document.querySelector('#retryLoad')?.addEventListener('click', () => loadShowcase());
+  }
+}
+
+applyLanguage();
+loadShowcase();

--- a/gallery/sitemap.xml
+++ b/gallery/sitemap.xml
@@ -2,4 +2,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://vincentwei1021.github.io/video-shotcraft/</loc><lastmod>2026-08-25</lastmod></url>
   <url><loc>https://vincentwei1021.github.io/video-shotcraft/library.html</loc><lastmod>2026-08-25</lastmod></url>
+  <url><loc>https://vincentwei1021.github.io/video-shotcraft/showcase.html</loc><lastmod>2026-08-25</lastmod></url>
 </urlset>

--- a/gallery/styles.css
+++ b/gallery/styles.css
@@ -1006,3 +1006,96 @@ kbd { padding: 0.2rem 0.34rem; border: 1px solid var(--line); border-radius: 5px
     -webkit-backdrop-filter: none;
   }
 }
+
+/* ---------- showcase page ---------- */
+
+.topbar-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--faint);
+  background: var(--surface-soft);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+.topbar-link:hover { color: var(--accent-text); border-color: var(--accent); }
+
+.showcase-intro { align-items: center; }
+.showcase-submit {
+  display: inline-flex;
+  align-items: center;
+  min-height: 46px;
+  padding: 0 1.5rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 750;
+  font-size: 0.9rem;
+  text-decoration: none;
+  white-space: nowrap;
+  box-shadow: var(--shadow);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+.showcase-submit:hover { transform: translateY(-1px); }
+
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.1rem;
+  align-items: start;
+}
+
+.showcase-cards-used {
+  margin: 0.55rem 0 0;
+  color: var(--faint);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+.showcase-cards-used span {
+  margin-right: 0.3rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.64rem;
+}
+
+/* 作者社交账号：可点的是链接，纯 handle（小红书号/抖音号）渲染为文本徽章 */
+.showcase-author {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--line);
+}
+.author-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 32px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-decoration: none;
+}
+a.author-chip:hover { color: var(--accent-text); border-color: var(--accent); }
+.author-chip svg { width: 13px; height: 13px; flex-shrink: 0; fill: currentColor; }
+.author-chip[data-platform="xiaohongshu"] svg { width: 16px; height: 16px; }
+
+@media (max-width: 900px) {
+  .showcase-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 620px) {
+  .showcase-grid { grid-template-columns: 1fr; }
+  .topbar-link { padding: 0 0.6rem; font-size: 0.68rem; }
+}

--- a/gallery/translations.js
+++ b/gallery/translations.js
@@ -71,6 +71,7 @@ window.GALLERY_I18N = {
       themeSystem: '系统',
       themeLight: '浅色',
       themeDark: '深色',
+      navShowcase: '用户作品',
     },
     en: {
       title: 'Shot Recipes & Motion Samples',
@@ -143,6 +144,7 @@ window.GALLERY_I18N = {
       themeSystem: 'Auto',
       themeLight: 'Light',
       themeDark: 'Dark',
+      navShowcase: 'Showcase',
     },
   },
   cardsZh: {


### PR DESCRIPTION
## 做了什么

给 Gallery 加一个 **Showcase（用户作品）页**，配一整条「issue 表单投稿 → 打标签审核 → Action 自动发布」的流水线。**投稿视频不进 git**——和现有 gallery-media 同模式，存 `showcase-media` release 资产。

### 投稿与发布链路

1. **投稿入口**：issue 表单 `.github/ISSUE_TEMPLATE/showcase.yml`（自动挂 `showcase` 标签）。字段：作品名、一句话介绍、用到的镜头卡、视频（≤10MB 附件直传 / 大文件外链）、**X / 小红书 / 抖音账号（可选）**、版权授权勾选。
2. **审核闸门**：维护者给 issue 加 `showcase-approved` 标签（两个标签已在仓库创建好）。
3. **自动发布**（`showcase-publish.yml` → `showcase-publish.py`）：下载视频（附件或外链，300MB 上限）→ ffprobe 校验 + h264 remux/转码 + faststart + 抽 poster → 转存 `showcase-media` release（首次自动建 release）→ 更新 release 上的 showcase.json → `workflow_dispatch` 触发 deploy-pages → 回帖告知已上线并关 issue；失败时自动在 issue 上留言。
4. **部署装配**：deploy-pages 新增一步下载 showcase-media 到 `site/showcase-media/`、showcase.json 放进 `site/api/`；release 尚不存在时回退空列表，不影响现有部署。

### 前端

- 新增 `gallery/showcase.html` + `showcase.js`：复用 styles.css 设计系统与主题/双语切换，卡片含视频（懒加载 + 视口内自动播放 + 全屏按钮）、标题、介绍、镜头卡、**作者社交徽章**（X/GitHub 裸 handle 自动拼主页链接；小红书号/抖音号拼不出 URL 时渲染为纯文本徽章，填链接则可点）。
- landing 与 library 顶栏加「用户作品 / Showcase」入口；sitemap 收录 showcase.html。
- `fetch-media.sh` 同步支持拉取 showcase 媒体做本地预览；`.gitignore` 排除 `gallery/showcase-media/` 与 `gallery/api/showcase.json`。

### SKILL.md

成片交付且用户满意后，邀请**一次** Showcase 投稿：给出表单链接，说明可附社交账号（观众能顺着卡片找到作者）、≤10MB 直拖/大文件外链；用户拒绝或不回应不再提。

## 已验证

- `showcase-publish.py` 表单解析/附件与外链提取有单测断言（含 markdown 链接附件、外链兜底）；py_compile 通过
- 两个 workflow + issue 表单 YAML 校验通过；showcase.js `node --check` 通过
- Playwright 本地实测：showcase 页中英/明暗四态、有投稿与空列表两态、landing 与 library 顶栏入口均渲染正常，样例视频视口内自动播放
- `build-seo.py` 重跑无回归（152 卡计数不变，sitemap 新增 showcase 条目）

## 注意

- merge 后 Showcase 页即上线（空列表 + 投稿 CTA）；`showcase` / `showcase-approved` 标签已建好，第一条投稿过审时 Action 会自动创建 `showcase-media` release
- 表单字段 label 是发布脚本的解析锚点，改 `showcase.yml` 须同步脚本里的 `FIELD_*` 常量（两处都有注释互指）
- 下架/改文案：下载 release 上的 showcase.json 改完 `--clobber` 传回，再手动 dispatch deploy-pages（workflow 头部注释有完整命令）

🤖 Generated with [Claude Code](https://claude.com/claude-code)