### PR TITLE
fix: 部署加资源哈希防缓存错配 + 首页语言按钮图标对齐

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,6 +46,30 @@ jobs:
             gallery/ site/
           touch site/.nojekyll
 
+      # Pages 给静态资源发 cache-control: max-age=600，部署后十分钟内浏览器
+      # 会拿旧 styles.css / app.js 配新 HTML（实际踩过：侧栏与顶栏样式全崩）。
+      # 按文件内容哈希给资源链接打 ?v=，每个 HTML 版本只引用自己那代资源。
+      - name: Stamp asset URLs for cache busting
+        run: |
+          python3 - <<'EOF'
+          import hashlib, pathlib, re
+          site = pathlib.Path('site')
+          assets = {}
+          for name in ('styles.css', 'app.js', 'showcase.js', 'translations.js'):
+              path = site / name
+              if path.exists():
+                  assets[name] = hashlib.md5(path.read_bytes()).hexdigest()[:8]
+          pattern = re.compile(
+              r'(?P<attr>href|src)="\./(?P<name>' + '|'.join(map(re.escape, assets)) + r')(?:\?v=[^"]*)?"')
+          for html in sorted(site.glob('*.html')):
+              text = html.read_text(encoding='utf-8')
+              stamped, hits = pattern.subn(
+                  lambda m: f'{m["attr"]}="./{m["name"]}?v={assets[m["name"]]}"', text)
+              if hits:
+                  html.write_text(stamped, encoding='utf-8')
+                  print(f'{html.name}: stamped {hits} asset link(s)')
+          EOF
+
       - name: Download motion previews from the gallery-media release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -151,6 +151,12 @@
       transition: color 150ms ease, border-color 150ms ease;
     }
     .language-toggle:hover { color: var(--text); border-color: rgba(211, 146, 60, 0.65); }
+    /* 图标外壳必须自己是 flex：默认 block 的话 svg 会贴在行高盒顶部，
+       比文字中线高约 2px（线上实测 36.3 vs 38.6） */
+    .language-toggle-icon {
+      display: inline-flex;
+      align-items: center;
+    }
     .language-toggle svg {
       width: 15px;
       height: 15px;
@@ -415,7 +421,7 @@
     <nav class="topbar-nav" aria-label="Site">
       <a class="topbar-nav-link" href="./showcase.html" data-l10n="navShowcase">Showcase</a>
       <button class="language-toggle" id="languageToggle" type="button" aria-label="Switch to Chinese">
-        <span aria-hidden="true">
+        <span class="language-toggle-icon" aria-hidden="true">
           <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="9.2"/><path d="M2.8 12h18.4M12 2.8c2.5 2.6 3.8 5.7 3.8 9.2S14.5 18.6 12 21.2c-2.5-2.6-3.8-5.7-3.8-9.2S9.5 5.4 12 2.8Z"/></svg>
         </span>
         <span id="languageToggleLabel">中文</span>


### PR DESCRIPTION
两个线上小毛病，一起修。

## 1. 新 HTML 配旧样式（缓存错配）

**现象**：PR #57 部署完成后，线上 library 页样式崩掉：关注面板行堆叠、图标撑满整列、链接带下划线，顶栏两个 toggle 的图标变成大黑圆。

**根因**：不是没部署——线上 `styles.css` 抓下来是新的（`.topbar-toggle` / `.follow-row` / `.link-arrow` 都在）。GitHub Pages 给静态资源发 `cache-control: max-age=600`，而 HTML 里引用 css/js 没有版本号，所以部署后十分钟窗口里**浏览器用缓存里的旧 styles.css 渲染了新 HTML**：新类名在旧 CSS 里没有规则，SVG 失去尺寸约束、`<a>` 没去下划线、flex 失效变堆叠。硬刷即恢复，但每次改 gallery 都有这个窗口。

**改法**：deploy-pages 装配后加一步 stamp，按文件内容 md5 前 8 位改写 `site/*.html` 的资源引用。

```
<link rel="stylesheet" href="./styles.css?v=529cd0d0">
<script src="./translations.js?v=052e9472" defer></script>
<script src="./app.js?v=e86bfc86" defer></script>
```

- 每个 HTML 版本只引用自己那一代资源 URL，新 HTML 请求的 URL 浏览器没缓存过，必然拉新文件。
- 哈希不变则 URL 不变，照旧命中浏览器缓存。
- 只作用于部署产物（`site/`），仓库里的 `gallery/` 与本地预览不受影响，无需手工维护版本号。

## 2. 首页语言按钮图标与文字不在一条水平线上

图标外壳 `span` 默认 `display: block`，15px 的 svg 贴在 19.5px 行高盒顶部，中线比文字高 2.3px（线上实测 svg 36.3 / 文字 38.6）。补上 `.language-toggle-icon { display: inline-flex }` 后两者中线都是 38.6。

library / showcase 的 `.topbar-toggle-icon` 本来就有这条规则，实测 delta 0，是我在首页那份内联 CSS 里漏了。

## 实测

- 按 workflow 的 rsync 规则在本地装配 `site/` 跑同一段 stamp 脚本：library 打 3 个链接、showcase 打 2 个，起 http 服务确认引用生效；workflow YAML 过 `yaml.safe_load`。
- 首页对齐用 Playwright 量 `getBoundingClientRect` 中线：修前 delta 2.3px，修后 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)