### PR TITLE
fix(showcase): align card heights and scroll long copy

### DIFF
--- a/gallery/showcase.js
+++ b/gallery/showcase.js
@@ -172,10 +172,12 @@ function itemMarkup(item, index) {
       </div>
       <div class="card-body">
         <div class="card-title">
-          <h3>${escapeHtml(item.title)}</h3>
+          <h3 id="showcase-title-${index}">${escapeHtml(item.title)}</h3>
         </div>
-        <p class="summary">${escapeHtml(item.description)}</p>
-        ${item.cards ? `<p class="showcase-cards-used"><span>${escapeHtml(text('cardsUsed'))}</span> ${escapeHtml(item.cards)}</p>` : ''}
+        <div class="showcase-copy-scroll" tabindex="0" aria-labelledby="showcase-title-${index}">
+          <p class="summary">${escapeHtml(item.description)}</p>
+          ${item.cards ? `<p class="showcase-cards-used"><span>${escapeHtml(text('cardsUsed'))}</span> ${escapeHtml(item.cards)}</p>` : ''}
+        </div>
         ${chips ? `<div class="showcase-author" aria-label="${escapeHtml(text('by'))}">${chips}</div>` : ''}
       </div>
     </article>`;

--- a/gallery/styles.css
+++ b/gallery/styles.css
@@ -1123,7 +1123,31 @@ kbd { padding: 0.2rem 0.34rem; border: 1px solid var(--line); border-radius: 5px
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1.1rem;
-  align-items: start;
+  align-items: stretch;
+}
+
+/* Every showcase card keeps the same body height. The demo remains the visual
+   anchor, the author row stays reachable, and longer copy scrolls in the
+   middle instead of making one card longer than the rest. */
+.showcase-card .card-body {
+  flex: 0 0 15.5rem;
+  block-size: 15.5rem;
+  min-height: 0;
+}
+.showcase-card .card-title { flex: 0 0 auto; }
+.showcase-copy-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin-top: 0.65rem;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+}
+.showcase-card .summary {
+  display: block;
+  min-height: 0;
+  margin: 0;
+  overflow: visible;
+  -webkit-line-clamp: unset;
 }
 
 .showcase-cards-used {


### PR DESCRIPTION
## Summary

- keep every Showcase card at a consistent height
- let long descriptions and shot-card lists scroll inside the card
- keep titles and author links visible while copy scrolls

## Verification

- node --check gallery/showcase.js
- git diff --check origin/main...HEAD
- browser-tested equal card heights and keyboard scrolling